### PR TITLE
chore: Migrate from Node.js to Bun runtime

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,82 @@
+# Copilot Instructions for 12dPL Language Server
+
+## Runtime Environment
+
+This project uses **Bun** as the primary runtime and package manager. **Do not use Node.js or npm**.
+
+### Key Commands
+
+```bash
+# Install dependencies
+bun install
+
+# Compile TypeScript
+bun run compile
+
+# Watch mode for development
+bun run watch
+
+# Run tests
+bun run test
+
+# Run all checks (typecheck + tests)
+bun run test:all
+```
+
+## Testing
+
+### Running Tests
+
+All tests are located in the `tests/` directory and use Bun's built-in test runner.
+
+```bash
+# Run all tests
+bun run test
+
+# Run a specific test file
+bun test tests/validator.test.ts
+
+# Run tests with verbose output
+bun test --verbose
+```
+
+### Test Fixtures
+
+Test fixtures are located in `client/testFixture/` and include `.4dm`, `.4do`, and `.h` files that are used by the test suite.
+
+### Writing Tests
+
+Use Bun's test API:
+
+```typescript
+import { describe, it, expect } from 'bun:test';
+
+describe('feature name', () => {
+    it('should do something', () => {
+        expect(result).toBe(expected);
+    });
+});
+```
+
+## Project Structure
+
+- `client/` — VS Code extension source (entry: `client/src/extension.ts`)
+- `server/` — Language server source (entry: `server/src/server.ts`)
+- `server/src/resources/` — JSON resources used at runtime
+- `server/src/antlr/` — ANTLR4 parser files for 12dPL grammar
+- `server/src/providers/` — LSP feature providers (completion, hover, formatting, etc.)
+- `tests/` — Unit and integration tests
+
+## Development Workflow
+
+1. Run `bun install` to install dependencies
+2. Run `bun run watch` to start the TypeScript compiler in watch mode
+3. Press F5 in VS Code to launch the extension in a test window
+4. Run `bun run test` to validate changes
+
+## Important Notes
+
+- **Do NOT use `npm` or `node` commands** - Use `bun` equivalents
+- **Do NOT add Node.js-specific dependencies** - Use Bun-compatible packages
+- The project uses ANTLR4 for parsing 12dPL grammar
+- The extension communicates via the Language Server Protocol (LSP)

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,14 +16,11 @@
 			"preLaunchTask": "bun: watch"
 		},
 		{
-			"type": "node",
+			"type": "bun",
 			"request": "attach",
 			"name": "Attach to Server",
-			"port": 6009,
-			"restart": true,
-			"outFiles": [
-				"${workspaceRoot}/server/out/**/*.js"
-			]
+			"url": "ws://localhost:6009",
+			"stopOnEntry": false
 		}
 	]
 }

--- a/client/src/compileFeature.ts
+++ b/client/src/compileFeature.ts
@@ -15,7 +15,7 @@ async function getCompilerInfo(compilerExe: string): Promise<CompilerInfo> {
     return new Promise((resolve) => {
         const config = workspace.getConfiguration('12dpl');
         const includePaths = (config.get<string[]>('compiler.includePaths') ?? []).map((p) => String(p).trim()).filter(Boolean);
-        const env = { ...process.env } as NodeJS.ProcessEnv;
+        const env = { ...process.env };
         if (includePaths.length > 0) {
             const sep = process.platform === 'win32' ? ';' : ':';
             env.PATH = `${includePaths.join(sep)}${sep}${env.PATH ?? ''}`;
@@ -210,7 +210,7 @@ export function registerCompileFeatures(context: ExtensionContext) {
 
         const configTop = workspace.getConfiguration('12dpl', document.uri);
         const includePathsTop = (configTop.get<string[]>('compiler.includePaths') ?? []).map((p) => String(p).trim()).filter(Boolean);
-        const envTop = { ...process.env } as NodeJS.ProcessEnv;
+        const envTop = { ...process.env };
         if (includePathsTop.length > 0) {
             const sep = ':';
             envTop.CPLUS_INCLUDE_PATH = `${envTop.CPLUS_INCLUDE_PATH ?? ''}${sep}${includePathsTop.join(sep)}${sep}${inputFileFolder}`;

--- a/server/package.json
+++ b/server/package.json
@@ -4,9 +4,6 @@
 	"version": "1.0.0",
 	"author": "Ben Olsen",
 	"license": "MIT",
-	"engines": {
-		"node": "*"
-	},
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/ben-nightworks/12dpl-lang-server"


### PR DESCRIPTION
This PR removes all Node.js references and fully migrates the project to use Bun as the runtime and package manager.

Changes:
- server/package.json: Removed engines node field
- .vscode/launch.json: Updated debug configuration to use Bun debugger
- client/src/compileFeature.ts: Removed NodeJS.ProcessEnv type casts  
- .github/copilot-instructions.md: Added development guidelines for using Bun

Notes:
- @types/node dependency retained since Bun implements Node.js APIs
- GitHub workflows already use Bun (no changes needed)
- Project compiles successfully with bun run compile