### PR TITLE
fix: Prevent false redeclaration errors in conditional preprocessor blocks

### DIFF
--- a/server/src/antlr/parsePipeline.ts
+++ b/server/src/antlr/parsePipeline.ts
@@ -8,6 +8,8 @@ export interface LexerAndParser {
 	lexer: proglang12dLexer;
 	parser: proglang12dParser;
 	transformedText: string;
+	/** 1-based line numbers that are inside conditional #if/#ifdef/#ifndef blocks (kept first branch). */
+	conditionalLines: Set<number>;
 }
 
 /**
@@ -15,7 +17,7 @@ export interface LexerAndParser {
  *
  * Keeps line numbers stable by replacing stripped lines with empty lines.
  */
-export function stripConditionalDirectives(documentText: string): string {
+export function stripConditionalDirectives(documentText: string): { text: string; conditionalLines: Set<number> } {
 	// The lexer has rules to skip some preprocessor directives, but real-world
 	// headers include macros containing '#'/'##' which can defeat simplistic lexer
 	// skipping and leak tokens into the parser.
@@ -26,13 +28,31 @@ export function stripConditionalDirectives(documentText: string): string {
 	//
 	// Additionally, content inside `#if 0` blocks is dead code and must be
 	// stripped entirely (not just the directive lines).
+	//
+	// For non-zero `#if`/`#ifdef`/`#ifndef` blocks, we keep only the first branch
+	// and strip `#else`/`#elif` branches to avoid false "already declared" errors
+	// when different branches declare the same variable.
 	const lines = documentText.split(/\r?\n/);
 	const out: string[] = [];
 	let inDirectiveContinuation = false;
-	// Track nested #if 0 blocks. When > 0, ALL lines are stripped.
-	let ifZeroDepth = 0;
+
+	// Stack tracks nested #if blocks.
+	// Each entry: 'if0' = inside #if 0 dead code, 'if-true' = in kept first branch, 'else' = in stripped #else/#elif branch
+	const ifStack: ('if0' | 'if-true' | 'else')[] = [];
+
+	/** 1-based line numbers inside conditional #if blocks (kept first branch). */
+	const conditionalLines = new Set<number>();
+	let lineNumber = 0;
+
+	/** Returns true if any entry in the stack means we should strip content. */
+	const shouldStripContent = () => ifStack.some(s => s === 'if0' || s === 'else');
+
+	/** Returns true if we are currently inside any conditional #if block (kept branch). */
+	const isInsideConditionalBlock = () => ifStack.some(s => s === 'if-true');
+
 	for (const line of lines) {
 		const trimmed = line.trimStart();
+		lineNumber++;
 
 		// Handle multi-line directive continuations (trailing backslash)
 		if (inDirectiveContinuation) {
@@ -43,22 +63,35 @@ export function stripConditionalDirectives(documentText: string): string {
 
 		// Check for preprocessor directive lines
 		if (trimmed.startsWith('#')) {
-			// Track #if 0 blocks to strip their contents
 			const directiveMatch = trimmed.match(/^#\s*(if|ifdef|ifndef|else|elif|endif)\b(.*)/);
 			if (directiveMatch) {
 				const directive = directiveMatch[1];
 				const rest = directiveMatch[2]?.trim() ?? '';
-				if (directive === 'if' && /^0\b/.test(rest)) {
-					ifZeroDepth++;
-				} else if ((directive === 'ifdef' || directive === 'ifndef' || directive === 'if') && ifZeroDepth > 0) {
-					// Nested #if inside an #if 0 block
-					ifZeroDepth++;
-				} else if (directive === 'endif' && ifZeroDepth > 0) {
-					ifZeroDepth--;
-				} else if ((directive === 'else' || directive === 'elif') && ifZeroDepth === 1) {
-					// #else/#elif at the same level as #if 0 means we're
-					// back to potentially live code (e.g. #if 0 ... #else ... #endif)
-					ifZeroDepth = 0;
+				if (directive === 'if' || directive === 'ifdef' || directive === 'ifndef') {
+					if (directive === 'if' && /^0\b/.test(rest)) {
+						ifStack.push('if0');
+					} else if (shouldStripContent()) {
+						// Nested #if inside already-stripped block — stays stripped
+						ifStack.push('if0');
+					} else {
+						ifStack.push('if-true');
+					}
+				} else if (directive === 'else' || directive === 'elif') {
+					if (ifStack.length > 0) {
+						const top = ifStack[ifStack.length - 1];
+						if (top === 'if0') {
+							// #else/#elif after #if 0 — content becomes live
+							ifStack[ifStack.length - 1] = 'if-true';
+						} else if (top === 'if-true') {
+							// #else/#elif after the kept first branch — strip this branch
+							ifStack[ifStack.length - 1] = 'else';
+						}
+						// If top === 'else', stay in 'else' (chained #elif after #else)
+					}
+				} else if (directive === 'endif') {
+					if (ifStack.length > 0) {
+						ifStack.pop();
+					}
 				}
 			}
 			out.push('');
@@ -66,15 +99,20 @@ export function stripConditionalDirectives(documentText: string): string {
 			continue;
 		}
 
-		// Inside #if 0 block — strip everything
-		if (ifZeroDepth > 0) {
+		// Inside stripped block — strip content
+		if (shouldStripContent()) {
 			out.push('');
 			continue;
 		}
 
+		// Track lines inside conditional blocks
+		if (isInsideConditionalBlock()) {
+			conditionalLines.add(lineNumber);
+		}
+
 		out.push(line);
 	}
-	return out.join('\n');
+	return { text: out.join('\n'), conditionalLines };
 }
 
 /**
@@ -328,14 +366,14 @@ export function wrapTopLevelScriptsPreservingLines(documentText: string): string
  *
  * This strips directive lines and wraps top-level script blocks.
  */
-export function prepareDocumentTextForParser(documentText: string): string {
-	const cleanedText = stripConditionalDirectives(documentText);
-	return wrapTopLevelScriptsPreservingLines(cleanedText);
+export function prepareDocumentTextForParser(documentText: string): { text: string; conditionalLines: Set<number> } {
+	const { text: cleanedText, conditionalLines } = stripConditionalDirectives(documentText);
+	return { text: wrapTopLevelScriptsPreservingLines(cleanedText), conditionalLines };
 }
 
 /** Creates and configures an ANTLR lexer/parser for a 12dPL document. */
 export function createLexerAndParser(documentText: string): LexerAndParser {
-	const transformedText = prepareDocumentTextForParser(documentText);
+	const { text: transformedText, conditionalLines } = prepareDocumentTextForParser(documentText);
 	const chars = new CharStream(transformedText);
 	const lexer = new proglang12dLexer(chars);
 	const tokens = new CommonTokenStream(lexer);
@@ -343,5 +381,5 @@ export function createLexerAndParser(documentText: string): LexerAndParser {
 	// Needed for traversals (e.g. symbol collection) that rely on ctx.children.
 	// antlr4 defaults can vary depending on runtime/build.
 	(parser as any).buildParseTrees = true;
-	return { lexer, parser, transformedText };
+	return { lexer, parser, transformedText, conditionalLines };
 }

--- a/server/src/antlr/validator.ts
+++ b/server/src/antlr/validator.ts
@@ -129,8 +129,9 @@ function extractIdentifierFromDeclarator(ctx: any): { name: string; line: number
  * @param tree The parse tree to validate
  * @param includeFileVariables Variables declared in include files (optional)
  */
-function validateRedeclarations(tree: any, includeFileVariables?: IncludeFileVariable[]): Diagnostic[] {
+function validateRedeclarations(tree: any, includeFileVariables?: IncludeFileVariable[], conditionalLines?: Set<number>): Diagnostic[] {
 	const diagnostics: Diagnostic[] = [];
+	const condLines = conditionalLines ?? new Set<number>();
 	
 	// Map of symbol name (lowercase) -> { sourceFile, kind } for symbols from include files
 	const includeVars = new Map<string, { sourceFile: string; kind: 'variable' | 'function' }>();
@@ -202,6 +203,11 @@ function validateRedeclarations(tree: any, includeFileVariables?: IncludeFileVar
 			// Allow function overloading: multiple functions with the same name
 			// but different parameter signatures are valid in 12dpl.
 			if (existing.isFunction && isFunction) {
+				return;
+			}
+			// If either declaration is inside a conditional #if block, suppress
+			// the error — the preprocessor ensures only one branch is active at runtime.
+			if (condLines.has(existing.line) || condLines.has(info.line)) {
 				return;
 			}
 			// Re-declaration in same scope!
@@ -847,7 +853,7 @@ export class Validator {
 		const diagnostics: Diagnostic[] = [];
 
 		try {
-			const { lexer, parser } = createLexerAndParser(documentText);
+			const { lexer, parser, conditionalLines } = createLexerAndParser(documentText);
 
 			const errorListener = new DiagnosticErrorListener();
 			lexer.removeErrorListeners();
@@ -859,7 +865,7 @@ export class Validator {
 			
 			// Only run semantic validation if there are no syntax errors
 			if (syntaxDiagnostics.length === 0) {
-				const redeclarationDiagnostics = validateRedeclarations(tree, includeFileVariables);
+				const redeclarationDiagnostics = validateRedeclarations(tree, includeFileVariables, conditionalLines);
 				return [...syntaxDiagnostics, ...redeclarationDiagnostics];
 			}
 			

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -813,3 +813,125 @@ void main() {
 		expect(syntaxErrors.length).toBeGreaterThan(0);
 	});
 });
+
+describe("#if/#else branch handling", () => {
+	test("does not report redeclaration for same variable in #if/#else branches", () => {
+		const code = `
+void main() {
+#if VERSION_4D >= 1400
+	Panel panel = Create_panel("test", TRUE);
+#else
+	Panel panel = Create_panel("test");
+#endif
+}
+`;
+		const diagnostics = Validator.Validate(code);
+		const redeclErrors = diagnostics.filter(d =>
+			d.message.includes("already declared")
+		);
+		expect(redeclErrors.length).toBe(0);
+	});
+
+	test("does not report redeclaration for #ifdef/#else branches", () => {
+		const code = `
+void main() {
+#ifdef SOME_FLAG
+	Integer breakline = 1;
+#else
+	Integer breakline = 2;
+#endif
+}
+`;
+		const diagnostics = Validator.Validate(code);
+		const redeclErrors = diagnostics.filter(d =>
+			d.message.includes("already declared")
+		);
+		expect(redeclErrors.length).toBe(0);
+	});
+
+	test("still strips #if 0 dead code", () => {
+		const code = `
+void main() {
+#if 0
+	this is dead code and should not parse
+#endif
+	Integer x = 1;
+}
+`;
+		const diagnostics = Validator.Validate(code);
+		const syntaxErrors = diagnostics.filter(d => d.severity === 1 /* Error */);
+		expect(syntaxErrors.length).toBe(0);
+	});
+
+	test("#if 0 with #else keeps the else branch", () => {
+		const code = `
+void main() {
+#if 0
+	Integer dead_var = 999;
+#else
+	Integer live_var = 1;
+#endif
+	Integer result = live_var + 1;
+}
+`;
+		const diagnostics = Validator.Validate(code);
+		const syntaxErrors = diagnostics.filter(d => d.severity === 1 /* Error */);
+		expect(syntaxErrors.length).toBe(0);
+	});
+
+	test("handles nested #if inside #if/#else without false redeclarations", () => {
+		const code = `
+void main() {
+#if CONDITION_A
+	#if CONDITION_B
+		Integer val = 1;
+	#else
+		Integer val = 2;
+	#endif
+#else
+	Integer val = 3;
+#endif
+}
+`;
+		const diagnostics = Validator.Validate(code);
+		const redeclErrors = diagnostics.filter(d =>
+			d.message.includes("already declared")
+		);
+		expect(redeclErrors.length).toBe(0);
+	});
+
+	test("does not report redeclaration when variable declared unconditionally then inside #if block", () => {
+		// Real-world pattern from fit_3pt_arcs_panel.4dm:
+		// Variable declared unconditionally, then re-declared inside a #if block.
+		// At runtime only one declaration exists (preprocessor either includes the block or not).
+		const code = `
+void process_elements() {
+	Integer breakline = 0;
+	Integer rv = 0;
+#if ALLOW_ONLY_LINE_STRINGS == 1
+	Integer breakline = 0;
+	rv = Get_breakline(breakline);
+#endif
+}
+`;
+		const diagnostics = Validator.Validate(code);
+		const redeclErrors = diagnostics.filter(d =>
+			d.message.includes("already declared")
+		);
+		expect(redeclErrors.length).toBe(0);
+	});
+
+	test("still reports real redeclaration outside any #if block", () => {
+		const code = `
+void main() {
+	Integer x = 1;
+	Integer x = 2;
+}
+`;
+		const diagnostics = Validator.Validate(code);
+		const redeclErrors = diagnostics.filter(d =>
+			d.message.includes("already declared")
+		);
+		expect(redeclErrors.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes false **"Variable is already declared"** errors caused by conditional preprocessor directives (`#if`/`#else`/`#ifdef`/`#endif`).

## Problems Fixed

### 1. `#if`/`#else` branches both kept (timestamp_panel.4dm)

```c
#if VERSION_4D >= 1400
    Panel panel = Create_panel(PROGRAM_NAME, TRUE);
#else
    Panel panel = Create_panel(PROGRAM_NAME);
#endif
```

Previously, `stripConditionalDirectives()` removed only the directive lines but kept code from **all branches**. Both `Panel panel` declarations survived into the parser, producing a false redeclaration error.

**Fix:** Now uses a stack-based approach — keeps only the first branch (`#if`/`#ifdef`/`#ifndef`) and strips `#else`/`#elif` branches. `#if 0` blocks still correctly strip the dead branch and keep the `#else` branch.

### 2. Variable declared unconditionally then inside `#if` block (fit_3pt_arcs_panel.4dm)

```c
Integer breakline = 0;       // line 588 - unconditional
// ...
#if ALLOW_ONLY_LINE_STRINGS == 1
Integer breakline = 0;       // line 622 - conditional
// ...
#endif
```

At runtime only one declaration exists (the preprocessor either includes the block or not), but the parser sees both.

**Fix:** `stripConditionalDirectives()` now tracks which lines are inside conditional `#if` blocks and returns them as a `Set<number>`. The validator suppresses redeclaration errors when either declaration is on a conditional line.

## Changes

### `server/src/antlr/parsePipeline.ts`
- `stripConditionalDirectives()` now returns `{ text, conditionalLines }` instead of just a string
- Stack-based tracking of `#if`/`#else`/`#endif` nesting with three states: `if0`, `if-true`, `else`
- Tracks 1-based line numbers inside kept conditional blocks
- `LexerAndParser` interface extended with `conditionalLines: Set<number>`
- `prepareDocumentTextForParser()` and `createLexerAndParser()` thread the set through

### `server/src/antlr/validator.ts`
- `validateRedeclarations()` accepts optional `conditionalLines` parameter
- `checkAndAddDeclaration()` skips the redeclaration error if either declaration is on a conditional line
- `ValidateWithIncludes()` passes `conditionalLines` from the parser to the validator

### `tests/validator.test.ts`
Added 7 new test cases:
- `#if`/`#else` same variable (no false error)
- `#ifdef`/`#else` same variable (no false error)
- `#if 0` dead code still stripped
- `#if 0` with `#else` keeps live branch
- Nested `#if` inside `#if`/`#else`
- Unconditional + conditional declaration (the fit_3pt_arcs pattern)
- Real redeclaration outside `#if` still reported

## Testing
- All **65 tests pass** (was 58, added 7)
- Compilation succeeds cleanly
