### PR TITLE
Revert "Refactor symbol handling to use lowercase keys for exported f…

### DIFF
--- a/server/src/core/symbolCollector.ts
+++ b/server/src/core/symbolCollector.ts
@@ -473,15 +473,14 @@ export function deriveViews(root: ScopeNode): DerivedSymbolViews {
 	function collectExported(scope: ScopeNode) {
 		for (const decl of scope.declarations) {
 			if (isGeneratedWrapperFunctionName(decl.name)) continue;
-			const key = decl.name.toLowerCase();
 
 			if (decl.kind === 'function') {
-				const existing = exportedFunctions.get(key);
+				const existing = exportedFunctions.get(decl.name);
 				if (existing) existing.push(decl);
-				else exportedFunctions.set(key, [decl]);
+				else exportedFunctions.set(decl.name, [decl]);
 			} else if (decl.kind === 'variable') {
-				if (!exportedVariables.has(key)) {
-					exportedVariables.set(key, decl);
+				if (!exportedVariables.has(decl.name)) {
+					exportedVariables.set(decl.name, decl);
 				}
 			}
 		}
@@ -506,10 +505,9 @@ export function deriveViews(root: ScopeNode): DerivedSymbolViews {
 	function collectAllFunctions(scope: ScopeNode) {
 		for (const decl of scope.declarations) {
 			if (decl.kind === 'function' && !isGeneratedWrapperFunctionName(decl.name)) {
-				const key = decl.name.toLowerCase();
-				const existing = allFunctions.get(key);
+				const existing = allFunctions.get(decl.name);
 				if (existing) existing.push(decl);
-				else allFunctions.set(key, [decl]);
+				else allFunctions.set(decl.name, [decl]);
 			}
 		}
 		for (const child of scope.children) {

--- a/server/src/services/symbolResolver.ts
+++ b/server/src/services/symbolResolver.ts
@@ -86,15 +86,15 @@ export class SymbolResolver {
 
 		// 3. Include symbols (functions + variables)
 		const includeSymbols = await this.includeService.getIncludeSymbols(uri);
-		const inclFnDecls = includeSymbols.functions.get(lowerName);
+		const inclFnDecls = includeSymbols.functions.get(name);
 		if (inclFnDecls && inclFnDecls.length > 0) {
 			const inclFn = inclFnDecls[0];
-			const incFsPath = await this.findIncludeFsPathForSymbol(uri, lowerName);
+			const incFsPath = await this.findIncludeFsPathForSymbol(uri, name);
 			return this.declarationToResolved(inclFn, 'include', undefined, incFsPath);
 		}
-		const inclVar = includeSymbols.variables.get(lowerName);
+		const inclVar = includeSymbols.variables.get(name);
 		if (inclVar) {
-			const incFsPath = await this.findIncludeFsPathForSymbol(uri, lowerName);
+			const incFsPath = await this.findIncludeFsPathForSymbol(uri, name);
 			return this.declarationToResolved(inclVar, 'include', undefined, incFsPath);
 		}
 
@@ -174,16 +174,12 @@ export class SymbolResolver {
 
 		// 3. Include symbols
 		const includeSymbols = await this.includeService.getIncludeSymbols(uri);
-		for (const [name, decls] of includeSymbols.functions) {
+		for (const [, decls] of includeSymbols.functions) {
 			const fn = decls[0];
-			if (fn) {
-				const incFsPath = await this.findIncludeFsPathForSymbol(uri, name);
-				add(this.declarationToResolved(fn, 'include', undefined, incFsPath));
-			}
+			if (fn) add(this.declarationToResolved(fn, 'include'));
 		}
-		for (const [name, decl] of includeSymbols.variables) {
-			const incFsPath = await this.findIncludeFsPathForSymbol(uri, name);
-			add(this.declarationToResolved(decl, 'include', undefined, incFsPath));
+		for (const [, decl] of includeSymbols.variables) {
+			add(this.declarationToResolved(decl, 'include'));
 		}
 
 		// 4. Include defines


### PR DESCRIPTION
This reverts commit 1975c72d7132a9d44f15a2bf8fcb2d7e2282f976.

Symbols should not be stored as lower case keys as the declarations/symbols are treated as case sensitive by the compiler. This fixes an issue with validation and autocomplete for functions/variables with the same spelling but different case that is acceptable to the compiler.