### PR TITLE
Feat\Use language-level file icons 

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -13,3 +13,14 @@ client/node_modules/**
 !client/node_modules/vscode-languageserver-types/**
 !client/node_modules/{minimatch,brace-expansion,concat-map,balanced-match}/**
 !client/node_modules/{semver,lru-cache,yallist}/**
+macros
+macros_mattmonk
+tests/**
+docs/**
+client/testFixture/**
+server/src/**
+.github/**
+bun.lock
+.eslintignore
+.eslintrc.json
+node_modules/**

--- a/Icons/12dpl-icon-theme.json
+++ b/Icons/12dpl-icon-theme.json
@@ -1,0 +1,15 @@
+{
+	"hidesExplorerArrows": false,
+	"iconDefinitions": {
+		"_4dm": {
+			"iconPath": "../Images/4dm.svg"
+		},
+		"_4do": {
+			"iconPath": "../Images/4do.svg"
+		}
+	},
+	"fileExtensions": {
+		"4dm": "_4dm",
+		"4do": "_4do"
+	}
+}

--- a/Images/4dm.svg
+++ b/Images/4dm.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- Document body -->
+  <path d="M6 3C6 1.89543 6.89543 1 8 1H19L26 8V29C26 30.1046 25.1046 31 24 31H8C6.89543 31 6 30.1046 6 29V3Z" fill="#1E88E5"/>
+  <!-- Folded corner -->
+  <path d="M19 1L26 8H21C19.8954 8 19 7.10457 19 6V1Z" fill="#90CAF9"/>
+  <!-- Text: 4dm -->
+  <text x="16" y="23" font-family="Consolas, monospace" font-size="10" font-weight="bold" fill="#FFFFFF" text-anchor="middle">4dm</text>
+</svg>

--- a/Images/4dm.svg
+++ b/Images/4dm.svg
@@ -1,8 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <!-- Document body -->
-  <path d="M6 3C6 1.89543 6.89543 1 8 1H19L26 8V29C26 30.1046 25.1046 31 24 31H8C6.89543 31 6 30.1046 6 29V3Z" fill="#1E88E5"/>
-  <!-- Folded corner -->
-  <path d="M19 1L26 8H21C19.8954 8 19 7.10457 19 6V1Z" fill="#90CAF9"/>
-  <!-- Text: 4dm -->
-  <text x="16" y="23" font-family="Consolas, monospace" font-size="10" font-weight="bold" fill="#FFFFFF" text-anchor="middle">4dm</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <text x="12" y="17" font-family="Roboto, sans-serif" font-size="11" font-weight="500" fill="#42A5F5" text-anchor="middle">4dm</text>
 </svg>

--- a/Images/4do.svg
+++ b/Images/4do.svg
@@ -1,8 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <!-- Document body -->
-  <path d="M6 3C6 1.89543 6.89543 1 8 1H19L26 8V29C26 30.1046 25.1046 31 24 31H8C6.89543 31 6 30.1046 6 29V3Z" fill="#43A047"/>
-  <!-- Folded corner -->
-  <path d="M19 1L26 8H21C19.8954 8 19 7.10457 19 6V1Z" fill="#A5D6A7"/>
-  <!-- Text: 4do -->
-  <text x="16" y="23" font-family="Consolas, monospace" font-size="10" font-weight="bold" fill="#FFFFFF" text-anchor="middle">4do</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <text x="12" y="17" font-family="Roboto, sans-serif" font-size="11" font-weight="500" fill="#66BB6A" text-anchor="middle">4do</text>
 </svg>

--- a/Images/4do.svg
+++ b/Images/4do.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- Document body -->
+  <path d="M6 3C6 1.89543 6.89543 1 8 1H19L26 8V29C26 30.1046 25.1046 31 24 31H8C6.89543 31 6 30.1046 6 29V3Z" fill="#43A047"/>
+  <!-- Folded corner -->
+  <path d="M19 1L26 8H21C19.8954 8 19 7.10457 19 6V1Z" fill="#A5D6A7"/>
+  <!-- Text: 4do -->
+  <text x="16" y="23" font-family="Consolas, monospace" font-size="10" font-weight="bold" fill="#FFFFFF" text-anchor="middle">4do</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -95,7 +95,24 @@
 					".4dm",
 					".h"
 				],
-				"configuration": "./language-configuration.json"
+				"configuration": "./language-configuration.json",
+				"icon": {
+					"light": "./Images/4dm.svg",
+					"dark": "./Images/4dm.svg"
+				}
+			},
+			{
+				"id": "12dpl-compiled",
+				"aliases": [
+					"12dPL Compiled"
+				],
+				"extensions": [
+					".4do"
+				],
+				"icon": {
+					"light": "./Images/4do.svg",
+					"dark": "./Images/4do.svg"
+				}
 			},
 			{
 				"id": "mtfsnippet",
@@ -126,13 +143,7 @@
 				"path": "./snippets/12dpl.tmSnippets.json"
 			}
 		],
-		"iconThemes": [
-			{
-				"id": "12dpl-icons",
-				"label": "12dPL File Icons",
-				"path": "./Icons/12dpl-icon-theme.json"
-			}
-		],
+
 		"configuration": {
 			"type": "object",
 			"title": "12dPL",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,13 @@
 				"path": "./snippets/12dpl.tmSnippets.json"
 			}
 		],
+		"iconThemes": [
+			{
+				"id": "12dpl-icons",
+				"label": "12dPL File Icons",
+				"path": "./Icons/12dpl-icon-theme.json"
+			}
+		],
 		"configuration": {
 			"type": "object",
 			"title": "12dPL",


### PR DESCRIPTION
## Summary

Replaces the custom icon theme (iconThemes) with language-level icon properties so that custom file icons for .4dm and .4do don't override the user's active icon theme (e.g. Material Icon Theme).

## Changes

- **Removed** the iconThemes contribution that replaced all VS Code icons
- **Added** icon property to the 12dpl language entry for .4dm files
- **Added** a new 12dpl-compiled language entry for .4do files with its own icon
- **Simplified** both SVG icons to a clean text-only style matching Material Icon Theme's approach
- The Icons/ folder and 12dpl-icon-theme.json are now unused and can be deleted