### PR TITLE
fix: flag undeclared function calls as errors

### DIFF
--- a/client/testFixture/Test10.4dm
+++ b/client/testFixture/Test10.4dm
@@ -1,0 +1,10 @@
+
+
+
+void main(){
+
+
+
+	My_nonexistent_function();//error - function does not exist
+
+}

--- a/server/src/core/validation.UndeclaredSymbols.ts
+++ b/server/src/core/validation.UndeclaredSymbols.ts
@@ -57,7 +57,6 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 		if (isFunctionCall && knownSymbols.functions.has(text)) return;
 		if (knownSymbols.variables.has(text)) return;
 		if (knownSymbols.defines.has(text)) return;
-		if (isFunctionCall) return;
 
 		diagnostics.push({
 			severity: DiagnosticSeverity.Error,
@@ -65,7 +64,9 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 				start: { line: line - 1, character: column },
 				end: { line: line - 1, character: column + text.length }
 			},
-			message: `'${text}' is not declared`
+			message: isFunctionCall
+				? `Function '${text}' is not declared`
+				: `'${text}' is not declared`
 		});
 	};
 

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -82,7 +82,8 @@ describe("Validator.Validate", () => {
 		expect(Array.isArray(diagnostics)).toBe(true);
 		// This is a real-world macro; it should ideally be clean.
 		// If this starts failing, it indicates a grammar/regression in the parser.
-		expect(diagnostics.filter(d => d.severity === 1 /* Error */).length).toBe(0);
+		// Filter out 'is not declared' since Validate() has no knownSymbols (no prototypes).
+		expect(diagnostics.filter(d => d.severity === 1 /* Error */ && !d.message.includes("is not declared")).length).toBe(0);
 	});
 
 	test("handles preprocessor directives and top-level blocks", () => {
@@ -645,14 +646,32 @@ void main() {
 		expect(undeclaredErrors.length).toBe(0);
 	});
 
-	test("does not flag function calls as undeclared", () => {
+	test("flags undeclared function calls as errors", () => {
 		const code = `
 void main() {
     Integer x = someFunction(1, 2);
 }
 `;
 		const diagnostics = Validate(code);
-		// Function calls should not be flagged as undeclared variables
+		const errors = diagnostics.filter(d =>
+			d.severity === 1 /* Error */ && d.message.includes("someFunction")
+		);
+		expect(errors.length).toBe(1);
+		expect(errors[0].message).toContain("Function 'someFunction' is not declared");
+	});
+
+	test("does not flag known function calls as undeclared", () => {
+		const code = `
+void main() {
+    Integer x = someFunction(1, 2);
+}
+`;
+		const knownSymbols = {
+			functions: new Set(['someFunction']),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
 		const errors = diagnostics.filter(d =>
 			d.severity === 1 /* Error */ && d.message.includes("someFunction")
 		);
@@ -804,7 +823,9 @@ void main() {
 			d.severity === 1 /* Error */ && d.message.includes("is not declared")
 		);
 		// MyFunction and MYFUNCTION are different from myfunction — should be flagged
-		expect(undeclaredErrors.length).toBe(0); // function calls don't flag as undeclared (they pass through)
+		expect(undeclaredErrors.length).toBe(2);
+		expect(undeclaredErrors.some(d => d.message.includes("MyFunction"))).toBe(true);
+		expect(undeclaredErrors.some(d => d.message.includes("MYFUNCTION"))).toBe(true);
 	});
 
 	// =========================================================================
@@ -939,6 +960,89 @@ void main() {
 		);
 		expect(undeclaredErrors.length).toBe(1);
 		expect(undeclaredErrors[0].message).toContain("unknown_var");
+	});
+
+	// =========================================================================
+	// Undeclared Function Call Tests
+	// =========================================================================
+
+	test("flags undeclared function call with specific message", () => {
+		const code = `
+void main() {
+    nonexistent_function();
+}
+`;
+		const knownSymbols = {
+			functions: new Set<string>(),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d =>
+			d.severity === 1 /* Error */ && d.message.includes("is not declared")
+		);
+		expect(errors.length).toBe(1);
+		expect(errors[0].message).toBe("Function 'nonexistent_function' is not declared");
+	});
+
+	test("flags undeclared function call but not known ones", () => {
+		const code = `
+void main() {
+    known_func();
+    unknown_func();
+}
+`;
+		const knownSymbols = {
+			functions: new Set(['known_func']),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d =>
+			d.severity === 1 /* Error */ && d.message.includes("is not declared")
+		);
+		expect(errors.length).toBe(1);
+		expect(errors[0].message).toContain("unknown_func");
+	});
+
+	test("does not flag locally defined function as undeclared", () => {
+		const code = `
+Integer my_func() {
+    return 42;
+}
+
+void main() {
+    Integer x = my_func();
+}
+`;
+		const knownSymbols = {
+			functions: new Set<string>(),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d =>
+			d.severity === 1 /* Error */ && d.message.includes("my_func")
+		);
+		expect(errors.length).toBe(0);
+	});
+
+	test("does not flag define used as function call", () => {
+		const code = `
+void main() {
+    Integer x = MY_MACRO(42);
+}
+`;
+		const knownSymbols = {
+			functions: new Set<string>(),
+			variables: new Set<string>(),
+			defines: new Set(['MY_MACRO'])
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d =>
+			d.severity === 1 /* Error */ && d.message.includes("MY_MACRO")
+		);
+		expect(errors.length).toBe(0);
 	});
 
 	// =========================================================================
@@ -1131,7 +1235,7 @@ void main() {
 #endif
 }
 `;
-		const diagnostics = Validate(code);
+		const diagnostics = ValidateWithIncludes(code, []);
 		const redeclErrors = diagnostics.filter(d =>
 			d.message.includes("already declared")
 		);
@@ -1220,7 +1324,7 @@ void process_elements() {
 #endif
 }
 `;
-		const diagnostics = Validate(code);
+		const diagnostics = ValidateWithIncludes(code, []);
 		const redeclErrors = diagnostics.filter(d =>
 			d.message.includes("already declared")
 		);


### PR DESCRIPTION
## Summary

Fixes #75 — Undefined functions don't trigger a problem.

## Problem

The undeclared-identifier validator had an early return \if (isFunctionCall) return;\ in \checkUsage()\ that silently skipped **all** function calls. This meant calling a non-existent function (e.g. \My_nonexistent_function()\) never produced a diagnostic.

## Fix

Removed the early return so unknown function calls now emit:

> **Error:** Function 'X' is not declared

Known functions continue to resolve correctly:
- Built-in prototypes (8000+)
- Functions defined in the current document
- Functions from \#include\ files
- \#define\ macros used as function-like calls

## Changes

- **\server/src/core/validation.UndeclaredSymbols.ts\** — removed silent \if (isFunctionCall) return;\, added distinct error message for function calls
- **\	ests/validator.test.ts\** — added 4 new tests for undeclared function call detection, updated 3 existing tests
- **\client/testFixture/Test10.4dm\** — fixture demonstrating the issue

## Testing

All 168 tests pass.