### PR TITLE
Fixed enriched prototype definitions to match compiler/doco

### DIFF
--- a/scripts/fix-enriched.ts
+++ b/scripts/fix-enriched.ts
@@ -1,0 +1,188 @@
+/**
+ * Fix script: updates functions.enriched.json to match functions.compiler.json
+ * 
+ * - Removes entries with no matching compiler function (by name)
+ * - Removes duplicate entries (same name + same normalized param signature)
+ * - Fixes return types to match compiler
+ * - Fixes parameter counts and types to match compiler
+ * - Strips non-ASCII characters from type and name fields (PDF artifacts)
+ * 
+ * Preserves the enriched description text (the whole point of the enriched file).
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+interface FunctionParam {
+	name: string;
+	type: string;
+}
+
+interface FunctionEntry {
+	name: string;
+	id: number;
+	returnType: string;
+	parameters: FunctionParam[];
+	description: string;
+}
+
+const resourcesDir = path.resolve(__dirname, "..", "server", "src", "resources");
+const compilerFunctions: FunctionEntry[] = JSON.parse(
+	fs.readFileSync(path.join(resourcesDir, "functions.compiler.json"), "utf-8")
+);
+const enrichedFunctions: FunctionEntry[] = JSON.parse(
+	fs.readFileSync(path.join(resourcesDir, "functions.enriched.json"), "utf-8")
+);
+
+// Build compiler lookup by lowercase name → overloads
+const compilerByName = new Map<string, FunctionEntry[]>();
+for (const fn of compilerFunctions) {
+	const key = fn.name.toLowerCase();
+	const existing = compilerByName.get(key);
+	if (existing) {
+		existing.push(fn);
+	} else {
+		compilerByName.set(key, [fn]);
+	}
+}
+
+function normalizeType(type: string): string {
+	return type.replace(/[^\x20-\x7E]/g, "").trim();
+}
+
+function normalizedParamSig(params: FunctionParam[]): string {
+	return params.map((p) => normalizeType(p.type).toLowerCase()).join(",");
+}
+
+function cleanNonAscii(value: string): string {
+	return value.replace(/[^\x20-\x7E]/g, "").trim();
+}
+
+/**
+ * Find the best matching compiler overload for an enriched entry.
+ */
+function findBestCompilerMatch(enriched: FunctionEntry): FunctionEntry | null {
+	const overloads = compilerByName.get(enriched.name.toLowerCase());
+	if (!overloads) return null;
+
+	// Exact param signature match (normalized)
+	const eSig = normalizedParamSig(enriched.parameters);
+	const exact = overloads.find((c) => normalizedParamSig(c.parameters) === eSig);
+	if (exact) return exact;
+
+	// Closest by param count
+	return overloads.reduce((best, cur) =>
+		Math.abs(cur.parameters.length - enriched.parameters.length) <
+		Math.abs(best.parameters.length - enriched.parameters.length)
+			? cur
+			: best
+	);
+}
+
+const stats = {
+	removed_no_match: 0,
+	removed_duplicate: 0,
+	fixed_return_type: 0,
+	fixed_param_count: 0,
+	fixed_param_type: 0,
+	fixed_non_ascii: 0,
+	fixed_id: 0,
+};
+
+const result: FunctionEntry[] = [];
+const seen = new Set<string>();
+
+for (const fn of enrichedFunctions) {
+	const match = findBestCompilerMatch(fn);
+
+	// Remove entries with no compiler match
+	if (!match) {
+		stats.removed_no_match++;
+		console.log(`REMOVED (no match): ${fn.name}`);
+		continue;
+	}
+
+	// Clean non-ASCII from all fields first
+	let nameClean = cleanNonAscii(fn.name);
+	if (nameClean !== fn.name) stats.fixed_non_ascii++;
+
+	let descClean = fn.description; // preserve description as-is (may have unicode intentionally)
+
+	// Fix return type
+	let returnType = cleanNonAscii(fn.returnType);
+	if (normalizeType(returnType).toLowerCase() !== normalizeType(match.returnType).toLowerCase()) {
+		console.log(`FIXED return type: ${fn.name}: "${returnType}" → "${match.returnType}"`);
+		returnType = match.returnType;
+		stats.fixed_return_type++;
+	}
+
+	// Fix parameters: adopt compiler's parameter types and count
+	let parameters: FunctionParam[];
+	if (fn.parameters.length !== match.parameters.length) {
+		// Parameter count mismatch — adopt compiler params but keep enriched names where possible
+		console.log(`FIXED param count: ${fn.name}: ${fn.parameters.length} → ${match.parameters.length}`);
+		parameters = match.parameters.map((cp, i) => ({
+			name: i < fn.parameters.length ? cleanNonAscii(fn.parameters[i].name) : cp.name,
+			type: cp.type,
+		}));
+		stats.fixed_param_count++;
+	} else {
+		// Same count — fix individual types
+		parameters = fn.parameters.map((ep, i) => {
+			const cp = match.parameters[i];
+			let name = cleanNonAscii(ep.name);
+			let type = cleanNonAscii(ep.type);
+
+			if (name !== ep.name) stats.fixed_non_ascii++;
+			if (type !== ep.type) stats.fixed_non_ascii++;
+
+			if (normalizeType(type).toLowerCase() !== normalizeType(cp.type).toLowerCase()) {
+				console.log(`FIXED param type: ${fn.name} param[${i}]: "${type}" → "${cp.type}"`);
+				type = cp.type;
+				stats.fixed_param_type++;
+			}
+			return { name, type };
+		});
+	}
+
+	// Fix ID to match compiler
+	let id = fn.id;
+	if (id !== match.id) {
+		console.log(`FIXED id: ${fn.name}: ${id} → ${match.id}`);
+		id = match.id;
+		stats.fixed_id++;
+	}
+
+	// Use compiler's canonical name casing
+	const name = match.name;
+
+	// Deduplicate: same name (lowercased) + same param signature
+	const dedupeKey = `${name.toLowerCase()}|${normalizedParamSig(parameters)}`;
+	if (seen.has(dedupeKey)) {
+		stats.removed_duplicate++;
+		console.log(`REMOVED (duplicate): ${name} (${parameters.map(p => p.type).join(", ")})`);
+		continue;
+	}
+	seen.add(dedupeKey);
+
+	result.push({
+		name,
+		id,
+		returnType,
+		parameters,
+		description: descClean,
+	});
+}
+
+// Write the fixed file
+const outputPath = path.join(resourcesDir, "functions.enriched.json");
+fs.writeFileSync(outputPath, JSON.stringify(result, null, 2) + "\n", "utf-8");
+
+console.log("\n✅ Fixed functions.enriched.json");
+console.log(`  Entries: ${enrichedFunctions.length} → ${result.length}`);
+console.log(`  Removed (no compiler match): ${stats.removed_no_match}`);
+console.log(`  Removed (duplicates): ${stats.removed_duplicate}`);
+console.log(`  Fixed return types: ${stats.fixed_return_type}`);
+console.log(`  Fixed param counts: ${stats.fixed_param_count}`);
+console.log(`  Fixed param types: ${stats.fixed_param_type}`);
+console.log(`  Fixed non-ASCII artifacts: ${stats.fixed_non_ascii}`);
+console.log(`  Fixed IDs: ${stats.fixed_id}`);

--- a/server/src/resources/functions.compiler.json
+++ b/server/src/resources/functions.compiler.json
@@ -84997,6 +84997,161 @@
     "description": "12dPL function Get_size"
   },
   {
+    "name": "Create_super_align",
+    "id": 2120,
+    "returnType": "Element",
+    "parameters": [],
+    "description": "Create an Element of type Super_Alignment. The function return value gives the actual Element created. If the Super Alignment string could not be created, then the returned Element will be null."
+  },
+  {
+    "name": "Create_super_align",
+    "id": 2121,
+    "returnType": "Element",
+    "parameters": [
+      {
+        "name": "seed",
+        "type": "Element"
+      }
+    ],
+    "description": "Create an Element of type Super_Alignment, and set the colour, name, style etc. of the new string to be the same as those from the Element seed. If the Super Alignment string could not be created, then the returned Element will be null."
+  },
+  {
+    "name": "Create_process",
+    "id": 2635,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "program_name",
+        "type": "Text"
+      },
+      {
+        "name": "command_line",
+        "type": "Text"
+      },
+      {
+        "name": "start_directory",
+        "type": "Text"
+      },
+      {
+        "name": "flags",
+        "type": "Integer"
+      },
+      {
+        "name": "inherit",
+        "type": "Integer"
+      },
+      {
+        "name": "&handle",
+        "type": "Process_Handle"
+      }
+    ],
+    "description": "This function calls the Microsoft CreateProcess function as defined in http://msdn.microsoft.com/en-us/library/ms682425%28v=vs.85%29.aspx. The 12d function gives access to the Microsoft CreateProcess arguments that are in bold (and also not have a // in front of them): BOOL WINAPI CreateProcess( __in_opt LPCTSTR lpApplicationName, __inout_opt LPTSTR lpCommandLine, // __in_opt LPSECURITY_ATTRIBUTES lpProcessAttributes, // __in_opt LPSECURITY_ATTRIBUTES lpThreadAttributes, __in BOOL bInheritHandles, __in DWORD dwCreationFlags, // __in_opt LPVOID lpEnvironment, __in_opt LPCTSTR lpCurrentDirectory, // __in LPSTARTUPINFO lpStartupInfo, // __out LPPROCESS_INFORMATION lpProcessInformation ); where program_name is passed as lpApplicationName, command_line is passed as dwCreationFlags lpCommandLine, start_directory is passed as lpCurrentDirectory, flags is passed as dwCreationFlags and inherit is passed as bInheritHandles. The handle to the created process is returned in Unknown handle. The macro can check if the process is still running by calling Process_exists. A function return value of zero indicates the function was successful. Note: The difference between this function and Create_process(Text program_name,Text command_line,Text start_directory,Integer flags,Integer wait,Integer inherit) is that a handle to the process is created and returned as handle and this can be checked to see if the process is still running. So there is no wait flag but there is more flexibility since the macro can check with Process_exists and decide when, and when not to wait. Note: Create_process can not be called from 12d Model Practise version."
+  },
+  {
+    "name": "Get_end_length",
+    "id": 2843,
+    "returnType": "Real",
+    "parameters": [
+      {
+        "name": "curve",
+        "type": "Curve"
+      }
+    ],
+    "description": "Get the end length of Curve curve and return it as the function return value."
+  },
+  {
+    "name": "View_remove_plot_data_textstyle",
+    "id": 3083,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "view",
+        "type": "View"
+      },
+      {
+        "name": "model_name",
+        "type": "Text"
+      },
+      {
+        "name": "prefix",
+        "type": "Text"
+      },
+      {
+        "name": "&internal_return",
+        "type": "Integer"
+      }
+    ],
+    "description": "Intended for 12D developers use only"
+  },
+  {
+    "name": "Get_name",
+    "id": 431,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "tin",
+        "type": "Tin"
+      },
+      {
+        "name": "&tin_name",
+        "type": "Text"
+      }
+    ],
+    "description": "Get the name of the Tin tin. The tin name is returned in the Text tin_name. A function return value of zero indicates success. If tin is null, the function return value is non-zero. Tin_models(Tin tin, Dynamic_Text &models_used) Name Integer Tin_models(Tin tin, Dynamic_Text &models_used) Description Get the names of all the models that were used to create the Tin tin. The model names are returned in the Dynamic_Text models_used. A function return value of zero indicates that the view names were returned successfully."
+  },
+  {
+    "name": "Get_size",
+    "id": 1352,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "&actual_width",
+        "type": "Integer"
+      },
+      {
+        "name": "&actual_height",
+        "type": "Integer"
+      }
+    ],
+    "description": "Get the width and height in pixels of the Draw_Box drawing area on the panel and return the values in actual_width and actual_height. See 5.61.10.11 Draw_Box for the calculations of width and height. A function return value of zero indicates the width and height were successfully returned."
+  },
+  {
+    "name": "Create_button",
+    "id": 7672,
+    "returnType": "Button",
+    "parameters": [
+      {
+        "name": "title_text",
+        "type": "Text"
+      },
+      {
+        "name": "reply",
+        "type": "Text"
+      },
+      {
+        "name": "bitmap_name",
+        "type": "Text"
+      }
+    ],
+    "description": "Create a Widget of type Button. The Button is created with image using file named bitmap_name and title_text a the text on the Button. The Text reply is the command that is sent by the Button back to the macro via Wait_on_widgets when the Button is clicked on. See Wait_on_widgets(Integer &id,Text &cmd,Text &msg). The function return value is the created Button. Panels and Widgets Page 1155 12d Model Macro Manual"
+  },
+  {
+    "name": "Set_anchor",
+    "id": 2822,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "curve",
+        "type": "Curve"
+      },
+      {
+        "name": "point",
+        "type": "Point"
+      }
+    ],
+    "description": "For the end of the Curve curve where the radius is infinity, set the co-ordinates of that position to point. For a leading transition, the anchor point is the start of curve. For a trailing transition, the anchor point is the end of curve. Page 238 Curve Chapter 5 12dPL Library Calls A function return value of zero indicates that the function call was successful."
+  },
+  {
     "name": "Get_size",
     "id": 1644,
     "returnType": "Integer",
@@ -88030,7 +88185,7 @@
     "returnType": "Integer",
     "parameters": [
       {
-        "name": "",
+        "name": "element",
         "type": "Element"
       },
       {
@@ -92034,7 +92189,7 @@
   },
   {
     "name": "Get_text_xy",
-    "id": 454,
+    "id": 100454,
     "returnType": "Integer",
     "parameters": [
       {
@@ -109134,31 +109289,31 @@
         "type": "Element"
       },
       {
-        "name": "x",
+        "name": "x[]",
         "type": "Real"
       },
       {
-        "name": "y",
+        "name": "y[]",
         "type": "Real"
       },
       {
-        "name": "z",
+        "name": "z[]",
         "type": "Real"
       },
       {
-        "name": "r",
+        "name": "r[]",
         "type": "Real"
       },
       {
-        "name": "f",
+        "name": "b[]",
         "type": "Integer"
       },
       {
-        "name": "num_pts",
+        "name": "num_verts",
         "type": "Integer"
       },
       {
-        "name": "offset",
+        "name": "start_vert",
         "type": "Integer"
       }
     ],
@@ -112270,7 +112425,7 @@
   },
   {
     "name": "Set_face_data",
-    "id": 80,
+    "id": 10080,
     "returnType": "Integer",
     "parameters": [
       {
@@ -112278,15 +112433,15 @@
         "type": "Element"
       },
       {
-        "name": "x",
+        "name": "x[]",
         "type": "Real"
       },
       {
-        "name": "y",
+        "name": "y[]",
         "type": "Real"
       },
       {
-        "name": "z",
+        "name": "z[]",
         "type": "Real"
       },
       {
@@ -112298,7 +112453,7 @@
   },
   {
     "name": "Set_face_data",
-    "id": 81,
+    "id": 10081,
     "returnType": "Integer",
     "parameters": [
       {
@@ -112306,15 +112461,15 @@
         "type": "Element"
       },
       {
-        "name": "x",
+        "name": "x[]",
         "type": "Real"
       },
       {
-        "name": "y",
+        "name": "y[]",
         "type": "Real"
       },
       {
-        "name": "z",
+        "name": "z[]",
         "type": "Real"
       },
       {
@@ -112322,7 +112477,7 @@
         "type": "Integer"
       },
       {
-        "name": "offset",
+        "name": "start_point",
         "type": "Integer"
       }
     ],
@@ -124888,7 +125043,7 @@
   },
   {
     "name": "Set_text_xy",
-    "id": 462,
+    "id": 100462,
     "returnType": "Integer",
     "parameters": [
       {

--- a/server/src/resources/functions.enriched.json
+++ b/server/src/resources/functions.enriched.json
@@ -20,7 +20,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get the i\u2019th token from the command-line. The token is returned by the Text argument. The arguments start from 1. A function return value of zero indicates the i\u2019th argument was successfully returned. For some example code, see 5.4 Command Line-Arguments. Page 78 Command Line-Arguments Chapter 5 12dPL Library Calls"
+    "description": "Get the i’th token from the command-line. The token is returned by the Text argument. The arguments start from 1. A function return value of zero indicates the i’th argument was successfully returned. For some example code, see 5.4 Command Line-Arguments. Page 78 Command Line-Arguments Chapter 5 12dPL Library Calls"
   },
   {
     "name": "Exit",
@@ -230,7 +230,7 @@
         "type": "Text"
       }
     ],
-    "description": "Convert all special characters < & > \u2019 \" in the Text text; into their legal XML forms & lt; & amp; & gt; & apos; & quot; The converted Text is the returned result of the function call."
+    "description": "Convert all special characters < & > ’ \" in the Text text; into their legal XML forms & lt; & amp; & gt; & apos; & quot; The converted Text is the returned result of the function call."
   },
   {
     "name": "From_text",
@@ -430,7 +430,7 @@
         "type": "Dynamic_Text"
       }
     ],
-    "description": "Break the Text text into separate words (tokens) and add the individual words to the Dynamic_Text dtext. The character used to break up the text into individual words is given by the Integer separator. Any characters between matching the character given by the Integer delimiter (including any characters equal to separator) are considered to be one word. For example, if the delimiter is double quotes \" and the separator is a semi-colon ; then This;is;\"an;example\" Text Page 91 12d Model Macro Manual has three words - \"this\", \"is\", and \"an;example\". Note: delimiter and separator are Integers and can be specified by the actual number of a character or by giving the actual character between single quotes. For example, separator = 32 is the number for a space separator = \u2019 \u2019 is the number for a space separator = \u2019a\u2019 will be the number for the letter a separator = \u2019\\t\u2019 will be the number for a tab The function return value is the number of words returned in dtext."
+    "description": "Break the Text text into separate words (tokens) and add the individual words to the Dynamic_Text dtext. The character used to break up the text into individual words is given by the Integer separator. Any characters between matching the character given by the Integer delimiter (including any characters equal to separator) are considered to be one word. For example, if the delimiter is double quotes \" and the separator is a semi-colon ; then This;is;\"an;example\" Text Page 91 12d Model Macro Manual has three words - \"this\", \"is\", and \"an;example\". Note: delimiter and separator are Integers and can be specified by the actual number of a character or by giving the actual character between single quotes. For example, separator = 32 is the number for a space separator = ’ ’ is the number for a space separator = ’a’ will be the number for the letter a separator = ’\\t’ will be the number for a tab The function return value is the number of words returned in dtext."
   },
   {
     "name": "From_text",
@@ -470,7 +470,7 @@
         "type": "Text"
       }
     ],
-    "description": "Break the Text input_string into separate words (tokens) and add the individual words to the Dynamic_Text output_words, the number of individual words is returned in output_count. The character used to break up the text into individual words is given by any characters in separators. Any characters between matching the character given by the Integer quote (including any characters in separators) are considered to be one word. For example, if the quote is double quotes \" and the separators is a semi-colon ; then This;is;\"an;example\" has three words - \"this\", \"is\", and \"an;example\". Note: quote is an Integer and can be specified as the number for the character or the character enclosed in single quotes. For example, quote = 32 is the number for a space quote = \u2019 \u2019 is the number for a space quote = \u2019a\u2019 will be the number for the letter a quote = \u2019\\t\u2019 will be the number for a tab honour_all_separators is for the case when there are multiple separator characters next to one another. For example to parse this comma separated string as 5 words set honour_all_separators to 1: 1,2,,3,4 and to parse this whitespaced string as 4 characters set honour_all_separators as 0: 1 2 3 4 It is possible to split just a portion of the string into words, to do this set concat_after_n_words to a non zero value, once the number of words has been reached the rest of the string will have the separators and delimiters removed and all set to the next word. If an error has occurred then an error message will be returned in error_message, for example: Page 92 Text Chapter 5 12dPL Library Calls \"String is empty!\" the string had no data \"Unmatched quote in input!\" the string contained a starting quote but no terminating quote before the end of the string, for example 123.0, 456.1, \"PM45653 \"Unexpected quote in middle of word! pos:\" indicates the position in the string where a quote follows a non separator character, for example 123.0,32\",45.0 A function return value of zero indicates that output_count and output_words were successfully returned."
+    "description": "Break the Text input_string into separate words (tokens) and add the individual words to the Dynamic_Text output_words, the number of individual words is returned in output_count. The character used to break up the text into individual words is given by any characters in separators. Any characters between matching the character given by the Integer quote (including any characters in separators) are considered to be one word. For example, if the quote is double quotes \" and the separators is a semi-colon ; then This;is;\"an;example\" has three words - \"this\", \"is\", and \"an;example\". Note: quote is an Integer and can be specified as the number for the character or the character enclosed in single quotes. For example, quote = 32 is the number for a space quote = ’ ’ is the number for a space quote = ’a’ will be the number for the letter a quote = ’\\t’ will be the number for a tab honour_all_separators is for the case when there are multiple separator characters next to one another. For example to parse this comma separated string as 5 words set honour_all_separators to 1: 1,2,,3,4 and to parse this whitespaced string as 4 characters set honour_all_separators as 0: 1 2 3 4 It is possible to split just a portion of the string into words, to do this set concat_after_n_words to a non zero value, once the number of words has been reached the rest of the string will have the separators and delimiters removed and all set to the next word. If an error has occurred then an error message will be returned in error_message, for example: Page 92 Text Chapter 5 12dPL Library Calls \"String is empty!\" the string had no data \"Unmatched quote in input!\" the string contained a starting quote but no terminating quote before the end of the string, for example 123.0, 456.1, \"PM45653 \"Unexpected quote in middle of word! pos:\" indicates the position in the string where a quote follows a non separator character, for example 123.0,32\",45.0 A function return value of zero indicates that output_count and output_words were successfully returned."
   },
   {
     "name": "To_text",
@@ -622,7 +622,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Set the nth position (where position starts at 1 for the first character) in the Text t to the character given by integer c. Note that \u2019c\u2019 can be used to specify the number corresponding to the letter c. A function return value of zero indicates the Text character is successfully set."
+    "description": "Set the nth position (where position starts at 1 for the first character) in the Text t to the character given by integer c. Note that ’c’ can be used to specify the number corresponding to the letter c. A function return value of zero indicates the Text character is successfully set."
   },
   {
     "name": "To_text",
@@ -678,7 +678,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Various fields of a Textstyle_Data can be turned of so they won\u2019t display (and so can\u2019t be set) in a Textstyle_Data pop-up. To turn off the Textstyle_Data fields, the Null(Textstyle_Data textdata,Integer mode) call is made with mode giving what fields are to be turned off. The values of mode and the Textstyle_Data field that they turn off are: Textstyle_Data_Textstyle = 0x00001, Textstyle_Data_Colour = 0x00002, Textstyle_Data_Type = 0x00004, Textstyle_Data_Size = 0x00008, Textstyle_Data_Offset = 0x00010, Textstyle_Data_Raise = 0x00020, Textstyle_Data_Justify_X = 0x00040, Textstyle_Data_Justify_Y = 0x00080, Textstyle_Data_Angle = 0x00100, Textstyle_Data_Slant = 0x00200, Textstyle_Data_X_Factor = 0x00400, Textstyle_Data_Name = 0x00800, Textstyle_Data_Underline = 0x01000, Textstyle_Data_Strikeout = 0x02000, Textstyle_Data_Italic = 0x04000, Textstyle_Data_Weight = 0x08000, Textstyle_Data_Whiteout = 0x10000, Textstyle_Data_Border = 0x20000, Textstyle_Data_Outline = 0x40000, Textstyle_Data_Border_Style = 0x80000, Textstyle_Data_All = 0xfffff, Note: the fields can be turned off one at a time by calling Null(Textstyle_Data textdata,Integer mode) a number of times, and/or more that one can be turned off at the one time by combining them with the logical OR operator \"|\". For example, Page 100 Textstyle Data Chapter 5 12dPL Library Calls Textstyle_Data_Offset | Textstyle_Data_Raise will turn off both the fields Textstyle_Data_Offset and Textstyle_Data_Raise. A function return value of zero indicates the parts of the Textstyle_Data were successfully nulled."
+    "description": "Various fields of a Textstyle_Data can be turned of so they won’t display (and so can’t be set) in a Textstyle_Data pop-up. To turn off the Textstyle_Data fields, the Null(Textstyle_Data textdata,Integer mode) call is made with mode giving what fields are to be turned off. The values of mode and the Textstyle_Data field that they turn off are: Textstyle_Data_Textstyle = 0x00001, Textstyle_Data_Colour = 0x00002, Textstyle_Data_Type = 0x00004, Textstyle_Data_Size = 0x00008, Textstyle_Data_Offset = 0x00010, Textstyle_Data_Raise = 0x00020, Textstyle_Data_Justify_X = 0x00040, Textstyle_Data_Justify_Y = 0x00080, Textstyle_Data_Angle = 0x00100, Textstyle_Data_Slant = 0x00200, Textstyle_Data_X_Factor = 0x00400, Textstyle_Data_Name = 0x00800, Textstyle_Data_Underline = 0x01000, Textstyle_Data_Strikeout = 0x02000, Textstyle_Data_Italic = 0x04000, Textstyle_Data_Weight = 0x08000, Textstyle_Data_Whiteout = 0x10000, Textstyle_Data_Border = 0x20000, Textstyle_Data_Outline = 0x40000, Textstyle_Data_Border_Style = 0x80000, Textstyle_Data_All = 0xfffff, Note: the fields can be turned off one at a time by calling Null(Textstyle_Data textdata,Integer mode) a number of times, and/or more that one can be turned off at the one time by combining them with the logical OR operator \"|\". For example, Page 100 Textstyle Data Chapter 5 12dPL Library Calls Textstyle_Data_Offset | Textstyle_Data_Raise will turn off both the fields Textstyle_Data_Offset and Textstyle_Data_Raise. A function return value of zero indicates the parts of the Textstyle_Data were successfully nulled."
   },
   {
     "name": "Set_data",
@@ -954,7 +954,7 @@
   },
   {
     "name": "Get_angle2",
-    "id": 3565,
+    "id": 3566,
     "returnType": "Integer",
     "parameters": [
       {
@@ -970,7 +970,7 @@
   },
   {
     "name": "Set_angle3",
-    "id": 3566,
+    "id": 3565,
     "returnType": "Integer",
     "parameters": [
       {
@@ -1527,7 +1527,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the three dimensional vector vect:\uf020 return the first component of vect in x. return the second component of vect in y return the third component of vect in z A function return value of zero indicates the components were successfully returned."
+    "description": "For the three dimensional vector vect: return the first component of vect in x. return the second component of vect in y return the third component of vect in z A function return value of zero indicates the components were successfully returned."
   },
   {
     "name": "Set_vector",
@@ -1967,7 +1967,7 @@
         "type": "Matrix3"
       }
     ],
-    "description": "For the three by three Matrix3 matrix, set all the values in the matrix to zero. A function return value of zero indicates the matrix was successfully zero\u2019d."
+    "description": "For the three by three Matrix3 matrix, set all the values in the matrix to zero. A function return value of zero indicates the matrix was successfully zero’d."
   },
   {
     "name": "Set_matrix_zero",
@@ -1979,7 +1979,7 @@
         "type": "Matrix4"
       }
     ],
-    "description": "For the four by four Matrix4 matrix, set all the values in the matrix to zero. A function return value of zero indicates the matrix was successfully zero\u2019d."
+    "description": "For the four by four Matrix4 matrix, set all the values in the matrix to zero. A function return value of zero indicates the matrix was successfully zero’d."
   },
   {
     "name": "Set_matrix_identity",
@@ -3061,7 +3061,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Start the macro from the file named macro_name; if run_now is not zero then also execute the macro. macro_name are comprised of \"macro_options user_macro_name macro_arguments\" where the macro_options (optional) is a list of zero or more key words (all starting with - (minus) character): -no_console don\u2019t display macro console -close_on_exit remove console when macro terminates -buttons have buttons for finish, restart and quit on console -allow_defaults allow default answers for console questions -execute_now same as run_now where macro_arguments (optional) are space delimited values and user_macro_name is the full path name to the 4do file to be executed For example Create_macro( \"-no_console -close_on_exit \\\"my macro name.4do\\\" \\\"arg 1\\\" \\\"arg 2\\\"\" , 1 ); A return value of zero indicates the function call was successful."
+    "description": "Start the macro from the file named macro_name; if run_now is not zero then also execute the macro. macro_name are comprised of \"macro_options user_macro_name macro_arguments\" where the macro_options (optional) is a list of zero or more key words (all starting with - (minus) character): -no_console don’t display macro console -close_on_exit remove console when macro terminates -buttons have buttons for finish, restart and quit on console -allow_defaults allow default answers for console questions -execute_now same as run_now where macro_arguments (optional) are space delimited values and user_macro_name is the full path name to the 4do file to be executed For example Create_macro( \"-no_console -close_on_exit \\\"my macro name.4do\\\" \\\"arg 1\\\" \\\"arg 2\\\"\" , 1 ); A return value of zero indicates the function call was successful."
   },
   {
     "name": "Get_user_name",
@@ -3073,7 +3073,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get user\u2019s name, the name currently logged onto the system. System Page 151 12d Model Macro Manual The name is returned in Text name. A function return value of zero indicates the name was returned successfully."
+    "description": "Get user’s name, the name currently logged onto the system. System Page 151 12d Model Macro Manual The name is returned in Text name. A function return value of zero indicates the name was returned successfully."
   },
   {
     "name": "Get_host_id",
@@ -3264,7 +3264,7 @@
       },
       {
         "name": "&handle",
-        "type": "Unknown"
+        "type": "Process_Handle"
       }
     ],
     "description": "This function calls the Microsoft CreateProcess function as defined in http://msdn.microsoft.com/en-us/library/ms682425%28v=vs.85%29.aspx. The 12d function gives access to the Microsoft CreateProcess arguments that are in bold (and also not have a // in front of them): BOOL WINAPI CreateProcess( __in_opt LPCTSTR lpApplicationName, __inout_opt LPTSTR lpCommandLine, // __in_opt LPSECURITY_ATTRIBUTES lpProcessAttributes, // __in_opt LPSECURITY_ATTRIBUTES lpThreadAttributes, __in BOOL bInheritHandles, __in DWORD dwCreationFlags, // __in_opt LPVOID lpEnvironment, __in_opt LPCTSTR lpCurrentDirectory, // __in LPSTARTUPINFO lpStartupInfo, // __out LPPROCESS_INFORMATION lpProcessInformation ); where program_name is passed as lpApplicationName, command_line is passed as dwCreationFlags lpCommandLine, start_directory is passed as lpCurrentDirectory, flags is passed as dwCreationFlags and inherit is passed as bInheritHandles. The handle to the created process is returned in Unknown handle. The macro can check if the process is still running by calling Process_exists. A function return value of zero indicates the function was successful. Note: The difference between this function and Create_process(Text program_name,Text command_line,Text start_directory,Integer flags,Integer wait,Integer inherit) is that a handle to the process is created and returned as handle and this can be checked to see if the process is still running. So there is no wait flag but there is more flexibility since the macro can check with Process_exists and decide when, and when not to wait. Note: Create_process can not be called from 12d Model Practise version."
@@ -3276,7 +3276,7 @@
     "parameters": [
       {
         "name": "handle",
-        "type": "Unknown"
+        "type": "Process_Handle"
       }
     ],
     "description": "Check to see if the process given by handle exists. That is, check that the process created by Create_process(Text program_name,Text command_line,Text start_directory,Integer flags,Integer inherit,Unknown &handle) is still running. A non-zero function return value indicates that the process handle is still running (i.e. the process exists). A zero function return value indicates that the process does not exist. Warning this is the opposite of most 12dPL function return values"
@@ -3624,7 +3624,7 @@
     "id": 1920,
     "returnType": "Uid",
     "parameters": [],
-    "description": "Get the next available Uid and return it as the function return value. This is often used in Undo\u2019s."
+    "description": "Get the next available Uid and return it as the function return value. This is often used in Undo’s."
   },
   {
     "name": "Get_next_id",
@@ -4156,7 +4156,7 @@
         "type": "File"
       }
     ],
-    "description": "Opens a file of name file_name with open type mode. The file unit is returned as File file. The file can be opened as a Unicode file with a specified encoding or as an ANSI file by using a non- blank value for the ccs_text parameter. The available modes are r open for reading. If the file does not exist then it fails. r+ open for update, that is for reading and writing. The file must exist. rb read binary w opens a file for writing. If the files exists, its current contents are destroyed. w+ opens a file for reading and writing. If the files exists, its current contents are\uf020 destroyed wb write binary a open for writing at the end of file (before the end of file marker). \uf020 If the file does not exist then it is created. a+ opens for reading and writing to the end of the file (before the end of file marker).\uf020 If the file does not exist then it is created. When a file is open for append (i.e. a or a+), it is impossible to overwrite information that is already in the file. Any writes are automatically added to the end of the file. ccs_text specifies the coded character set to use and can have the values: ccs_text = \"ccs = UTF-8\" Page 176 Input/Output Chapter 5 12dPL Library Calls ccs_text = \"ccs = UTF-16LE\" ccs_text = \"ccs = UNICODE\" or ccs_text = \"\" (leave it blank) if ANSI encoding is required. For example File_open(\"test file\", \"w\",\"ccs=UNICODE\",file_handle); Note: BOM detection only applies to files that are opened in Unicode mode (that is, by passing a non blank ccs parameter). If the file already exists and is opened for reading or appending, the Byte Order Mark (BOM), if it present in the file, determines the encoding. The BOM encoding takes precedence over the encoding that is specified by the ccs flag. The ccs encoding is only used when no BOM is present or the file is a new file. The following table summarises the use of Byte Order Marks (BOM\u2019s) for the various ccs flags given to File_open and what happens when there is a BOM in an existing file. Encodings Used When Opening a File Based on non blank ccs Flag and BOM ccs flag No BOM (or new file) BOM: UTF-8 BOM: UTF-16 UNICODE UTF-16LE UTF-8 UTF-16LE UTF-8 UTF-8 UTF-8 UTF-16LE UTF-16LE UTF-16LE UTF-8 UTF-16LE Files opened for writing in Unicode mode (non-blank ccs) automatically have a BOM written to them. When a file that begins with a Byte Order Mark (BOM) is opened, the file pointer is positioned after the BOM (that is, at the start of the file's actual content). For more information on ANSI, ASCII, Unicode, UTF\u2019s and BOM\u2019s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the file was opened successfully."
+    "description": "Opens a file of name file_name with open type mode. The file unit is returned as File file. The file can be opened as a Unicode file with a specified encoding or as an ANSI file by using a non- blank value for the ccs_text parameter. The available modes are r open for reading. If the file does not exist then it fails. r+ open for update, that is for reading and writing. The file must exist. rb read binary w opens a file for writing. If the files exists, its current contents are destroyed. w+ opens a file for reading and writing. If the files exists, its current contents are destroyed wb write binary a open for writing at the end of file (before the end of file marker).  If the file does not exist then it is created. a+ opens for reading and writing to the end of the file (before the end of file marker). If the file does not exist then it is created. When a file is open for append (i.e. a or a+), it is impossible to overwrite information that is already in the file. Any writes are automatically added to the end of the file. ccs_text specifies the coded character set to use and can have the values: ccs_text = \"ccs = UTF-8\" Page 176 Input/Output Chapter 5 12dPL Library Calls ccs_text = \"ccs = UTF-16LE\" ccs_text = \"ccs = UNICODE\" or ccs_text = \"\" (leave it blank) if ANSI encoding is required. For example File_open(\"test file\", \"w\",\"ccs=UNICODE\",file_handle); Note: BOM detection only applies to files that are opened in Unicode mode (that is, by passing a non blank ccs parameter). If the file already exists and is opened for reading or appending, the Byte Order Mark (BOM), if it present in the file, determines the encoding. The BOM encoding takes precedence over the encoding that is specified by the ccs flag. The ccs encoding is only used when no BOM is present or the file is a new file. The following table summarises the use of Byte Order Marks (BOM’s) for the various ccs flags given to File_open and what happens when there is a BOM in an existing file. Encodings Used When Opening a File Based on non blank ccs Flag and BOM ccs flag No BOM (or new file) BOM: UTF-8 BOM: UTF-16 UNICODE UTF-16LE UTF-8 UTF-16LE UTF-8 UTF-8 UTF-8 UTF-16LE UTF-16LE UTF-16LE UTF-8 UTF-16LE Files opened for writing in Unicode mode (non-blank ccs) automatically have a BOM written to them. When a file that begins with a Byte Order Mark (BOM) is opened, the file pointer is positioned after the BOM (that is, at the start of the file's actual content). For more information on ANSI, ASCII, Unicode, UTF’s and BOM’s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the file was opened successfully."
   },
   {
     "name": "File_open",
@@ -4240,7 +4240,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Go to the position pos in the File file. Position pos has normally been found by a previous File_tell call. If the file open type was a or a+, then a File_seek cannot be used to position for a write in any part of the file that existed when the file was opened. Page 178 Input/Output Chapter 5 12dPL Library Calls If you have to File_seek to the beginning of the file, use File_tell to get the initial position and File_seek to it rather than to position 0. So for a Unicode file, if you have to File_seek to the beginning of the file but after the BOM you need to first have used a File_tell to get and record the position of the initial start of the file when it is opened (for a Unicode file, File_open positions after the BOM) and then to File_seek to that recorded beginning of the file rather than to File_seek to position 0. For more information on ANSI, ASCII, Unicode, UTF\u2019s and BOM\u2019s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the file position was successfully found."
+    "description": "Go to the position pos in the File file. Position pos has normally been found by a previous File_tell call. If the file open type was a or a+, then a File_seek cannot be used to position for a write in any part of the file that existed when the file was opened. Page 178 Input/Output Chapter 5 12dPL Library Calls If you have to File_seek to the beginning of the file, use File_tell to get the initial position and File_seek to it rather than to position 0. So for a Unicode file, if you have to File_seek to the beginning of the file but after the BOM you need to first have used a File_tell to get and record the position of the initial start of the file when it is opened (for a Unicode file, File_open positions after the BOM) and then to File_seek to that recorded beginning of the file rather than to File_seek to position 0. For more information on ANSI, ASCII, Unicode, UTF’s and BOM’s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the file position was successfully found."
   },
   {
     "name": "File_flush",
@@ -4264,7 +4264,7 @@
         "type": "File"
       }
     ],
-    "description": "Rewind the File file to its beginning. WARNING: This function is not to be used with a Unicode file. If the file is a Unicode file then File_rewind will rewind to BEFORE the BOM. Then writing out any information will overwrite the BOM. So for a Unicode file, to correctly position to the beginning of the file but after the BOM you need to first have used a File_tell when opening the file to get and record position of the initial start of the file (for a Unicode file, File_open positions after the BOM) and then to File_seek to that recorded beginning of the file rather than to File_seek to position 0. For more information on ANSI, ASCII, Unicode, UTF\u2019s and BOM\u2019s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the file was successfully rewound."
+    "description": "Rewind the File file to its beginning. WARNING: This function is not to be used with a Unicode file. If the file is a Unicode file then File_rewind will rewind to BEFORE the BOM. Then writing out any information will overwrite the BOM. So for a Unicode file, to correctly position to the beginning of the file but after the BOM you need to first have used a File_tell when opening the file to get and record position of the initial start of the file (for a Unicode file, File_open positions after the BOM) and then to File_seek to that recorded beginning of the file rather than to File_seek to position 0. For more information on ANSI, ASCII, Unicode, UTF’s and BOM’s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the file was successfully rewound."
   },
   {
     "name": "File_read",
@@ -4348,7 +4348,7 @@
         "type": "Text"
       }
     ],
-    "description": "Read length bytes from the binary file file and return it as Text in value. Note - this works for UNICODE files. For more information on ANSI, ASCII, Unicode, UTF\u2019s and BOM\u2019s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the Text was successfully returned."
+    "description": "Read length bytes from the binary file file and return it as Text in value. Note - this works for UNICODE files. For more information on ANSI, ASCII, Unicode, UTF’s and BOM’s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the Text was successfully returned."
   },
   {
     "name": "File_read",
@@ -4368,7 +4368,7 @@
         "type": "Text"
       }
     ],
-    "description": "Read length bytes from the binary file file and return it as Text in value. Note - this only works for ANSI Text. If any of the characters of Text is not ANSI, then a non-zero function return value is returned. WARNING: This function is not to be used for Unicode files. For Unicode files, use File_read_unicode(File file,Integer length,Text &value) instead. For more information on ANSI, ASCII, Unicode, UTF\u2019s and BOM\u2019s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the Text was successfully returned."
+    "description": "Read length bytes from the binary file file and return it as Text in value. Note - this only works for ANSI Text. If any of the characters of Text is not ANSI, then a non-zero function return value is returned. WARNING: This function is not to be used for Unicode files. For Unicode files, use File_read_unicode(File file,Integer length,Text &value) instead. For more information on ANSI, ASCII, Unicode, UTF’s and BOM’s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the Text was successfully returned."
   },
   {
     "name": "File_write",
@@ -4388,7 +4388,7 @@
         "type": "Text"
       }
     ],
-    "description": "Write out value as length lots of one byte ANSI characters to the binary file file. If any of the characters of Text is not ANSI, then no data is written out and a non-zero function return value is returned. If there is less than length characters in Text then the number of characters is brought up to length by writing out null padding. WARNING: This function is not to be used for Unicode files. For Unicode files, use File_write_unicode(File file,Integer length,Text value) instead. For more information on ANSI, ASCII, Unicode, UTF\u2019s and BOM\u2019s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the Text was successfully written."
+    "description": "Write out value as length lots of one byte ANSI characters to the binary file file. If any of the characters of Text is not ANSI, then no data is written out and a non-zero function return value is returned. If there is less than length characters in Text then the number of characters is brought up to length by writing out null padding. WARNING: This function is not to be used for Unicode files. For Unicode files, use File_write_unicode(File file,Integer length,Text value) instead. For more information on ANSI, ASCII, Unicode, UTF’s and BOM’s, please see Set Ups.hwhich is a copy of the information from the 12d Model Reference manual. A function return value of zero indicates the Text was successfully written."
   },
   {
     "name": "File_write",
@@ -4808,7 +4808,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Open the file called filename, and append the 12d Ascii of the Element elt to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then write the name of the Model containing elt to the file before writing out elt. If output_model_name = 0 then don\u2019t write out the Model name. For output in full tin format see 5.17.4.1 MACRO_CALL_WRITE_FULL_TIN_4D. A function return value of zero indicates the data was successfully written."
+    "description": "Open the file called filename, and append the 12d Ascii of the Element elt to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then write the name of the Model containing elt to the file before writing out elt. If output_model_name = 0 then don’t write out the Model name. For output in full tin format see 5.17.4.1 MACRO_CALL_WRITE_FULL_TIN_4D. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "Write_4d_ascii",
@@ -4840,7 +4840,7 @@
         "type": "Real"
       }
     ],
-    "description": "Open the file called filename, and append the 12d Ascii of the Element elt to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then write the name of the Model containing elt to the file before writing out elt. Page 190 Input/Output Chapter 5 12dPL Library Calls If output_model_name = 0 then don\u2019t write out the Model name. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
+    "description": "Open the file called filename, and append the 12d Ascii of the Element elt to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then write the name of the Model containing elt to the file before writing out elt. Page 190 Input/Output Chapter 5 12dPL Library Calls If output_model_name = 0 then don’t write out the Model name. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "Write_4d_ascii",
@@ -4864,7 +4864,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Open the file called filename, and append the 12d Ascii of all the Elements in the Dynamic_Element list to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of the Model containing each Element to the file before writing out the Element. The Model name is not repeated if is the same as the previous Element). If output_model_name = 0 then don\u2019t write out the Model names. For output in full tin format see 5.17.4.1 MACRO_CALL_WRITE_FULL_TIN_4D. A function return value of zero indicates the data was successfully written."
+    "description": "Open the file called filename, and append the 12d Ascii of all the Elements in the Dynamic_Element list to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of the Model containing each Element to the file before writing out the Element. The Model name is not repeated if is the same as the previous Element). If output_model_name = 0 then don’t write out the Model names. For output in full tin format see 5.17.4.1 MACRO_CALL_WRITE_FULL_TIN_4D. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "Write_4d_ascii",
@@ -4896,7 +4896,7 @@
         "type": "Real"
       }
     ],
-    "description": "Open the file called filename, and append the 12d Ascii of all the Elements in the Dynamic_Element list to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of the Model containing each Element to the file before writing out the Element. The Model name is not repeated if is the same as the previous Element). If output_model_name = 0 then don\u2019t write out the Model names. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
+    "description": "Open the file called filename, and append the 12d Ascii of all the Elements in the Dynamic_Element list to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of the Model containing each Element to the file before writing out the Element. The Model name is not repeated if is the same as the previous Element). If output_model_name = 0 then don’t write out the Model names. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "Write_4d_ascii",
@@ -4928,7 +4928,7 @@
         "type": "Real"
       }
     ],
-    "description": "Open the file called filename, and append the 12d Ascii of all the Elements in the Model model to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then write the name of model out to the file before the Elements. If output_model_name = 0 then don\u2019t write out the Model name. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
+    "description": "Open the file called filename, and append the 12d Ascii of all the Elements in the Model model to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then write the name of model out to the file before the Elements. If output_model_name = 0 then don’t write out the Model name. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "Write_4d_ascii",
@@ -5080,7 +5080,7 @@
         "type": "Real"
       }
     ],
-    "description": "Write all the Elements in the Dynamic_Element list to the file filename using the format indicated by the file extension. If the extension of filename is .12dxml or 12dxmlz, then the output file will be processed as of12d Input/Output Page 193 12d Model Macro Manual XML format - normal and zipped accordingly. If the extension of filename is .12da or 12daz, then the output file will be processed as of 12d Ascii format - normal and zipped accordingly. Any other file extension will be process as 12da. If the file format is not zipped, then new information would be append at the end of existing file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of the Model containing each Element to the file before writing out the Element. If output_model_name = 0 then don\u2019t write out the Model names. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
+    "description": "Write all the Elements in the Dynamic_Element list to the file filename using the format indicated by the file extension. If the extension of filename is .12dxml or 12dxmlz, then the output file will be processed as of12d Input/Output Page 193 12d Model Macro Manual XML format - normal and zipped accordingly. If the extension of filename is .12da or 12daz, then the output file will be processed as of 12d Ascii format - normal and zipped accordingly. Any other file extension will be process as 12da. If the file format is not zipped, then new information would be append at the end of existing file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of the Model containing each Element to the file before writing out the Element. If output_model_name = 0 then don’t write out the Model names. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "Write_12d",
@@ -5112,7 +5112,7 @@
         "type": "Real"
       }
     ],
-    "description": "Write all the Elements in the Dynamic_Element list to the file filename using the format indicated by the file extension. If the extension of filename is .12dxml or 12dxmlz, then the output file will be processed as of12d XML format - normal and zipped accordingly. If the extension of filename is .12da or 12daz, then the output file will be processed as of 12d Ascii format - normal and zipped accordingly. Any other file extension will be process as 12da. If the file format is not zipped, then new information would be append at the end of existing file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of the Model containing each Element to the file before writing out the Element. If output_model_name = 0 then don\u2019t write out the Model names. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
+    "description": "Write all the Elements in the Dynamic_Element list to the file filename using the format indicated by the file extension. If the extension of filename is .12dxml or 12dxmlz, then the output file will be processed as of12d XML format - normal and zipped accordingly. If the extension of filename is .12da or 12daz, then the output file will be processed as of 12d Ascii format - normal and zipped accordingly. Any other file extension will be process as 12da. If the file format is not zipped, then new information would be append at the end of existing file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of the Model containing each Element to the file before writing out the Element. If output_model_name = 0 then don’t write out the Model names. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "Write_12d_data",
@@ -5144,7 +5144,7 @@
         "type": "Real"
       }
     ],
-    "description": "Write all the Elements in the Model model to the file filename using the format indicated by the file extension. If the extension of filename is .12dxml or 12dxmlz, then the output file will be processed as of12d XML format - normal and zipped accordingly. If the extension of filename is .12da or 12daz, then the output file will be processed as of 12d Ascii format - normal and zipped accordingly. Any other file extension will be process as 12da. If the file format is not zipped, then new information would be append at the end of existing file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of model to the file before writing out the Elements data. If output_model_name = 0 then don\u2019t write out the Model names. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
+    "description": "Write all the Elements in the Model model to the file filename using the format indicated by the file extension. If the extension of filename is .12dxml or 12dxmlz, then the output file will be processed as of12d XML format - normal and zipped accordingly. If the extension of filename is .12da or 12daz, then the output file will be processed as of 12d Ascii format - normal and zipped accordingly. Any other file extension will be process as 12da. If the file format is not zipped, then new information would be append at the end of existing file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then if write the name of model to the file before writing out the Elements data. If output_model_name = 0 then don’t write out the Model names. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "Create_menu",
@@ -5236,7 +5236,7 @@
         "type": "Text"
       }
     ],
-    "description": "When called, the Menu menu is displayed on the screen with screen co-ordinates of (across_rel,down_rel) relative to the cursor position. The menu remains displayed until a menu button is selected. When a menu button is selected, the menu is removed from the screen and the appropriate button return code returned in the Text variable reply. Whilst displayed, the menu can be moved in 12d Model by using the mouse. When the selection is made, the final absolute position of the menu is returned as (across_rel,down_rel). A function return value of zero indicates that a successful menu selection was made. Thus the sequence used to define and display a menu and the relevant functions used are: (a) a Menu variable is created which is used when referring to this particular menu. The menu title is defined when the menu variable is created. Use: Create_menu(Text menu_title) For example Menu menu = Create_menu(\"Test\"); (b) the menu buttons are added to the menu structure in the order that they will appear in the menu. The button text and the text that will be returned to the macro if the button is selected are both supplied. Use: Menus Page 197 12d Model Macro Manual Create_button(Menu menu,Text button_text,Text reply) For example Create_button(menu,\"First options\",\"Op1\"); Create_button(menu,\"Second options\",\"Op2\"); Create_button(menu,\"Finish\",\"Fin\"); (c) the menu is displayed on the screen. The menu will continued to be displayed until a menu button is selected. When the menu button is selected, the menu is removed from the screen and the appropriate button return code returned to the macro. Use: Display(Menu menu,Integer row_pos,Integer col_pos,\uf020 Text &reply) Display_relative(Menu menu,Integer row_pos,Integer col_pos,\uf020 Text &reply) For example Display(menu,5,10,reply); A more complete example of defining and using a menu is: void main() { // create a menu with title \"Silly Menu\" Menu menu = Create_menu(\"Silly Menu\"); /* add menu button with titles \"Read\", \"Write\", \"Draw\" and \"Quit\". The returns codes for the buttons are the same as the button titles */ Create_button(menu,\"Read\",\"Read\"); Create_button(menu,\"Write\",\"Write\"); Create_button(menu,\"Draw\",\"Draw\"); Create_button(menu,\"Quit\",\"Quit\"); /* display the menu on the screen at the current cursor position and wait for a button to selected. When a button is selected, print out its return code If the return code isn't \"Quit\", redisplay the menu. */ Text reply; do { Display(menu,-1,-1,reply); Print(reply); Print(\"\\n\"); } while(reply != \"Quit\"); }"
+    "description": "When called, the Menu menu is displayed on the screen with screen co-ordinates of (across_rel,down_rel) relative to the cursor position. The menu remains displayed until a menu button is selected. When a menu button is selected, the menu is removed from the screen and the appropriate button return code returned in the Text variable reply. Whilst displayed, the menu can be moved in 12d Model by using the mouse. When the selection is made, the final absolute position of the menu is returned as (across_rel,down_rel). A function return value of zero indicates that a successful menu selection was made. Thus the sequence used to define and display a menu and the relevant functions used are: (a) a Menu variable is created which is used when referring to this particular menu. The menu title is defined when the menu variable is created. Use: Create_menu(Text menu_title) For example Menu menu = Create_menu(\"Test\"); (b) the menu buttons are added to the menu structure in the order that they will appear in the menu. The button text and the text that will be returned to the macro if the button is selected are both supplied. Use: Menus Page 197 12d Model Macro Manual Create_button(Menu menu,Text button_text,Text reply) For example Create_button(menu,\"First options\",\"Op1\"); Create_button(menu,\"Second options\",\"Op2\"); Create_button(menu,\"Finish\",\"Fin\"); (c) the menu is displayed on the screen. The menu will continued to be displayed until a menu button is selected. When the menu button is selected, the menu is removed from the screen and the appropriate button return code returned to the macro. Use: Display(Menu menu,Integer row_pos,Integer col_pos, Text &reply) Display_relative(Menu menu,Integer row_pos,Integer col_pos, Text &reply) For example Display(menu,5,10,reply); A more complete example of defining and using a menu is: void main() { // create a menu with title \"Silly Menu\" Menu menu = Create_menu(\"Silly Menu\"); /* add menu button with titles \"Read\", \"Write\", \"Draw\" and \"Quit\". The returns codes for the buttons are the same as the button titles */ Create_button(menu,\"Read\",\"Read\"); Create_button(menu,\"Write\",\"Write\"); Create_button(menu,\"Draw\",\"Draw\"); Create_button(menu,\"Quit\",\"Quit\"); /* display the menu on the screen at the current cursor position and wait for a button to selected. When a button is selected, print out its return code If the return code isn't \"Quit\", redisplay the menu. */ Text reply; do { Display(menu,-1,-1,reply); Print(reply); Print(\"\\n\"); } while(reply != \"Quit\"); }"
   },
   {
     "name": "Append",
@@ -5584,7 +5584,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the i\u2019th Real from the Dynamic_Real real_list. The Real is returned in value. A function return value of zero indicates the i\u2019th Real was returned successfully."
+    "description": "Get the i’th Real from the Dynamic_Real real_list. The Real is returned in value. A function return value of zero indicates the i’th Real was returned successfully."
   },
   {
     "name": "Append",
@@ -5684,7 +5684,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the i\u2019th Integer from the Dynamic_Integer integer_list. The Integer is returned in value. A function return value of zero indicates the i\u2019th Integer was returned successfully."
+    "description": "Get the i’th Integer from the Dynamic_Integer integer_list. The Integer is returned in value. A function return value of zero indicates the i’th Integer was returned successfully."
   },
   {
     "name": "Append",
@@ -5784,7 +5784,7 @@
         "type": "Integer64"
       }
     ],
-    "description": "Get the i\u2019th Integer from the Dynamic_Integer64 integer_list. The Integer64 is returned in value. A function return value of zero indicates the i\u2019th Integer64 was returned successfully."
+    "description": "Get the i’th Integer from the Dynamic_Integer64 integer_list. The Integer64 is returned in value. A function return value of zero indicates the i’th Integer64 was returned successfully."
   },
   {
     "name": "Get_x",
@@ -6108,7 +6108,7 @@
         "type": "Real"
       }
     ],
-    "description": "Sign of radius. For a leading transition, set the end radius of the transition trans to radius. For a trailing transition, set the start radius of the transition trans to radius. Page 222 Spirals and Transitions Chapter 5 12dPL Library Calls Note - the radius is a signed value. \uf020 If radius > 0 the transition curves to the right.\uf020 If radius <0, the transition curves to the left. A function return value of zero indicates that the function call was successful."
+    "description": "Sign of radius. For a leading transition, set the end radius of the transition trans to radius. For a trailing transition, set the start radius of the transition trans to radius. Page 222 Spirals and Transitions Chapter 5 12dPL Library Calls Note - the radius is a signed value.  If radius > 0 the transition curves to the right. If radius <0, the transition curves to the left. A function return value of zero indicates that the function call was successful."
   },
   {
     "name": "Set_direction",
@@ -7041,18 +7041,6 @@
       }
     ],
     "description": "For the full Curve of curve, return the length to the end of the full curve as the function return value."
-  },
-  {
-    "name": "Get_end_length",
-    "id": 2843,
-    "returnType": "Real",
-    "parameters": [
-      {
-        "name": "curve",
-        "type": "Curve"
-      }
-    ],
-    "description": "Get the end length of Curve curve and return it as the function return value."
   },
   {
     "name": "Get_shift_x",
@@ -8448,7 +8436,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name does not exist then create it as type Text and give it the value att.\uf020 if the first attribute called att_name does exist and it is type Text, then set its value to att. If the attribute exists and is not of type Text, then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Attributes attr, if the attribute called att_name does not exist then create it as type Text and give it the value att. if the first attribute called att_name does exist and it is type Text, then set its value to att. If the attribute exists and is not of type Text, then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -8468,7 +8456,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name does not exist then create it as type Integer and give it the value att.\uf020 if the attribute called att_name does exist and it is type Integer, then set its value to att. If the attribute exists and is not of type Integer then a non-zero return value is returned. User Defined Attributes Page 269 12d Model Macro Manual A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Attributes attr, if the attribute called att_name does not exist then create it as type Integer and give it the value att. if the attribute called att_name does exist and it is type Integer, then set its value to att. If the attribute exists and is not of type Integer then a non-zero return value is returned. User Defined Attributes Page 269 12d Model Macro Manual A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -8488,7 +8476,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name does not exist then create it as type Real and give it the value att.\uf020 if the first attribute called att_name does exist and it is type Real, then set its value to att. If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Attributes attr, if the attribute called att_name does not exist then create it as type Real and give it the value att. if the first attribute called att_name does exist and it is type Real, then set its value to att. If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -8508,7 +8496,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name does not exist then create it as type Uid and give it the value att.\uf020 if the first attribute called att_name does exist and it is type Uid, then set its value to att. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Attributes attr, if the attribute called att_name does not exist then create it as type Uid and give it the value att. if the first attribute called att_name does exist and it is type Uid, then set its value to att. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -8528,7 +8516,7 @@
         "type": "Attributes"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name does not exist then create it as type Attributes and give it the value att.\uf020 if the first attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Attributes attr, if the attribute called att_name does not exist then create it as type Attributes and give it the value att. if the first attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -8548,7 +8536,7 @@
         "type": "Integer64"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name does not exist then create it as type 64 bit Integer and give it the value att.\uf020 if the first attribute called att_name does exist and it is type 64 bit Integer, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Attributes attr, if the attribute called att_name does not exist then create it as type 64 bit Integer and give it the value att. if the first attribute called att_name does exist and it is type 64 bit Integer, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -8568,7 +8556,7 @@
         "type": "Guid"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name does not exist then create it as type Guid and give it the value att.\uf020 if the first attribute called att_name does exist and it is type Guid, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Attributes attr, if the attribute called att_name does not exist then create it as type Guid and give it the value att. if the first attribute called att_name does exist and it is type Guid, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -8588,7 +8576,7 @@
         "type": "Attribute_Blob"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name does not exist then create it as type Attribute_Blob (binary) and give it the value att.\uf020 if the first attribute called att_name does exist and it is type Attribute_Blob (binary), then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Attributes attr, if the attribute called att_name does not exist then create it as type Attribute_Blob (binary) and give it the value att. if the first attribute called att_name does exist and it is type Attribute_Blob (binary), then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -8652,7 +8640,7 @@
   },
   {
     "name": "Set_attribute",
-    "id": 3250,
+    "id": 3249,
     "returnType": "Integer",
     "parameters": [
       {
@@ -8880,7 +8868,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name with type Text does not exist then create it and give it the value att.\uf020 if the attributes called att_name with type Text does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set. Page 276 User Defined Attributes Chapter 5 12dPL Library Calls"
+    "description": "For the Attributes attr, if the attribute called att_name with type Text does not exist then create it and give it the value att. if the attributes called att_name with type Text does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set. Page 276 User Defined Attributes Chapter 5 12dPL Library Calls"
   },
   {
     "name": "Set_attribute_by_type",
@@ -8900,7 +8888,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name with type Integer does not exist then create it and give it the value att.\uf020 if the attributes called att_name with type Integer does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
+    "description": "For the Attributes attr, if the attribute called att_name with type Integer does not exist then create it and give it the value att. if the attributes called att_name with type Integer does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
   },
   {
     "name": "Set_attribute_by_type",
@@ -8920,7 +8908,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name with type Real does not exist then create it and give it the value att.\uf020 if the attributes called att_name with type Real does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
+    "description": "For the Attributes attr, if the attribute called att_name with type Real does not exist then create it and give it the value att. if the attributes called att_name with type Real does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
   },
   {
     "name": "Set_attribute_by_type",
@@ -8940,7 +8928,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name with type Uid does not exist then create it and give it the value att.\uf020 if the attributes called att_name with type Uid does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
+    "description": "For the Attributes attr, if the attribute called att_name with type Uid does not exist then create it and give it the value att. if the attributes called att_name with type Uid does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
   },
   {
     "name": "Set_attribute_by_type",
@@ -8960,7 +8948,7 @@
         "type": "Attributes"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name with type Attributes (group) does not exist then create it and give it User Defined Attributes Page 277 12d Model Macro Manual the value att.\uf020 if the attributes called att_name with type Attributes (group) does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
+    "description": "For the Attributes attr, if the attribute called att_name with type Attributes (group) does not exist then create it and give it User Defined Attributes Page 277 12d Model Macro Manual the value att. if the attributes called att_name with type Attributes (group) does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
   },
   {
     "name": "Set_attribute_by_type",
@@ -8980,7 +8968,7 @@
         "type": "Integer64"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name with type 64 bit Integer does not exist then create it and give it the value att.\uf020 if the attributes called att_name with type 64 bit Integer does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
+    "description": "For the Attributes attr, if the attribute called att_name with type 64 bit Integer does not exist then create it and give it the value att. if the attributes called att_name with type 64 bit Integer does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
   },
   {
     "name": "Set_attribute_by_type",
@@ -9000,7 +8988,7 @@
         "type": "Guid"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name with type Guid does not exist then create it and give it the value att.\uf020 if the attributes called att_name with type Guid does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
+    "description": "For the Attributes attr, if the attribute called att_name with type Guid does not exist then create it and give it the value att. if the attributes called att_name with type Guid does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
   },
   {
     "name": "Set_attribute_by_type",
@@ -9020,7 +9008,7 @@
         "type": "Attribute_Blob"
       }
     ],
-    "description": "For the Attributes attr,\uf020 if the attribute called att_name with type Attribute_Blob (binary) does not exist then create it and give it the value att.\uf020 if the attributes called att_name with type Attribute_Blob (binary) does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
+    "description": "For the Attributes attr, if the attribute called att_name with type Attribute_Blob (binary) does not exist then create it and give it the value att. if the attributes called att_name with type Attribute_Blob (binary) does exist, then assign the value of the first one to att. A function return value of zero indicates the attribute value is successfully set."
   },
   {
     "name": "Insert_attribute_at_position",
@@ -10143,7 +10131,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the Project,\uf020 if the attribute called att_name does not exist then create it as type Uid and give it the value uid.\uf020 if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. Page 298 Project Chapter 5 12dPL Library Calls A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Project, if the attribute called att_name does not exist then create it as type Uid and give it the value uid. if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. Page 298 Project Chapter 5 12dPL Library Calls A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_project_attribute",
@@ -10159,7 +10147,7 @@
         "type": "Attributes"
       }
     ],
-    "description": "For the Project,\uf020 if the attribute called att_name does not exist then create it as type Attributes and give it the value att.\uf020 if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Project, if the attribute called att_name does not exist then create it as type Attributes and give it the value att. if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_project_attribute",
@@ -11215,7 +11203,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the Model model,\uf020 if the attribute called att_name does not exist then create it as type Uid and give it the value att.\uf020 if the attribute called att_name does exist and it is type Uid, then set its value to att. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Model model, if the attribute called att_name does not exist then create it as type Uid and give it the value att. if the attribute called att_name does exist and it is type Uid, then set its value to att. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_model_attribute",
@@ -11235,7 +11223,7 @@
         "type": "Attributes"
       }
     ],
-    "description": "For the Model model,\uf020 if the attribute called att_name does not exist then create it as type Attributes and give it the value att.\uf020 if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Model model, if the attribute called att_name does not exist then create it as type Attributes and give it the value att. if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_model_attribute",
@@ -12803,6 +12791,10 @@
         "type": "Text"
       },
       {
+        "name": "value",
+        "type": "Real"
+      },
+      {
         "name": "&internal_return",
         "type": "Integer"
       }
@@ -13032,30 +13024,6 @@
   {
     "name": "View_remove_draw_data_textstyle",
     "id": 3080,
-    "returnType": "Integer",
-    "parameters": [
-      {
-        "name": "view",
-        "type": "View"
-      },
-      {
-        "name": "model_name",
-        "type": "Text"
-      },
-      {
-        "name": "prefix",
-        "type": "Text"
-      },
-      {
-        "name": "&internal_return",
-        "type": "Integer"
-      }
-    ],
-    "description": "Intended for 12D developers use only"
-  },
-  {
-    "name": "View_remove_plot_data_textstyle",
-    "id": 3081,
     "returnType": "Integer",
     "parameters": [
       {
@@ -14167,7 +14135,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the Element elt,\uf020 if the attribute called att_name does not exist in the element then create it as type Uid and give it the value uid.\uf020 if the attribute called att_name does exist and it is type Uid, then set its value to att. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element elt, if the attribute called att_name does not exist in the element then create it as type Uid and give it the value uid. if the attribute called att_name does exist and it is type Uid, then set its value to att. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -14187,7 +14155,7 @@
         "type": "Attributes"
       }
     ],
-    "description": "For the Element elt,\uf020 if the attribute called att_name does not exist in the element then create it as type Attributes and give it the value att.\uf020 if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element elt, if the attribute called att_name does not exist in the element then create it as type Attributes and give it the value att. if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_attribute",
@@ -15194,7 +15162,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the (x,y,z) coordinate of np\u2019th point of the tin. The x value is returned in Real x. The y value is returned in Real y. The z value is returned in Real z. A function return value of zero indicates the coordinate of the point was successfully returned."
+    "description": "Get the (x,y,z) coordinate of np’th point of the tin. The x value is returned in Real x. The y value is returned in Real y. The z value is returned in Real z. A function return value of zero indicates the coordinate of the point was successfully returned."
   },
   {
     "name": "Tin_get_triangle_points",
@@ -15222,7 +15190,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the three points of nt\u2019th triangle of the tin. The first point value is returned in Integer p1. The second point value is returned in Integer p2. The third point value is returned in Integer p3. The normal to a triangle in the tin is considered to be pointing \"upwards\". That is, the normal points in the direction of what is considered the upper side of the tin. For example for a ground tin, the normal points upward. Looking onto the triangle from down the direction of the normal, the points p1, p2 and p3 are in a clockwise order around the triangle. This is opposite to the right-hand screw rule. p1 normal pointing \"up\" p3 p2 Tin Element Page 381 12d Model Macro Manual Note: this is the opposite to the order of points in a triangle in a trimesh. See 5.51 Trimesh Element. A function return value of zero indicates the points were successfully returned"
+    "description": "Get the three points of nt’th triangle of the tin. The first point value is returned in Integer p1. The second point value is returned in Integer p2. The third point value is returned in Integer p3. The normal to a triangle in the tin is considered to be pointing \"upwards\". That is, the normal points in the direction of what is considered the upper side of the tin. For example for a ground tin, the normal points upward. Looking onto the triangle from down the direction of the normal, the points p1, p2 and p3 are in a clockwise order around the triangle. This is opposite to the right-hand screw rule. p1 normal pointing \"up\" p3 p2 Tin Element Page 381 12d Model Macro Manual Note: this is the opposite to the order of points in a triangle in a trimesh. See 5.51 Trimesh Element. A function return value of zero indicates the points were successfully returned"
   },
   {
     "name": "Tin_get_triangle_neighbours",
@@ -15250,7 +15218,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the three neighbour triangles of the nt\u2019th triangle of the tin. The first triangle neighbour is returned in Integer n1. The second triangle neighbour is returned in Integer n2. The third triangle neighbour is returned in Integer n3. A function return value of zero indicates the triangles were successfully returned."
+    "description": "Get the three neighbour triangles of the nt’th triangle of the tin. The first triangle neighbour is returned in Integer n1. The second triangle neighbour is returned in Integer n2. The third triangle neighbour is returned in Integer n3. A function return value of zero indicates the triangles were successfully returned."
   },
   {
     "name": "Tin_get_point_from_point",
@@ -16294,7 +16262,7 @@
         "type": "Real"
       }
     ],
-    "description": "Set the coordinate data (x,y,z) for the i\u2019th vertex (the vertex with index number i) of the super Element super where the x value to set is in Real x. the y value to set is in Real y. the z value to set is in Real z. If the Element super is not of type Super, then the function return value is set to a non zero value. A function return value of zero indicates the data was successfully set."
+    "description": "Set the coordinate data (x,y,z) for the i’th vertex (the vertex with index number i) of the super Element super where the x value to set is in Real x. the y value to set is in Real y. the z value to set is in Real z. If the Element super is not of type Super, then the function return value is set to a non zero value. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_super_vertex_coord",
@@ -16322,7 +16290,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the coordinate data (x,y,z) for the i\u2019th vertex (the vertex with index number i) of the super Element super. The x coordinate is returned in Real x. The y coordinate is returned in Real y. The z coordinate is returned in Real z. If the Element super is not of type Super, then the function return value is set to a non zero value. A return value of 0 indicates the function call was successful."
+    "description": "Get the coordinate data (x,y,z) for the i’th vertex (the vertex with index number i) of the super Element super. The x coordinate is returned in Real x. The y coordinate is returned in Real y. The z coordinate is returned in Real z. If the Element super is not of type Super, then the function return value is set to a non zero value. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_data",
@@ -16358,7 +16326,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Set the (x,y,z,r,f) data for the i\u2019th vertex of the super Element super where the x value to set is the Real x. the y value to set is the Real y. the z value to set is the Real z. the radius value to set is the Real r. the major/minor arc bulge value to set is the Integer b (0 for minor arc < 180 degrees, non zero for major arc > 180 degrees). If the Element super is not of type Super, then the function return value is set to a non zero value. A function return value of zero indicates the data was successfully set."
+    "description": "Set the (x,y,z,r,f) data for the i’th vertex of the super Element super where the x value to set is the Real x. the y value to set is the Real y. the z value to set is the Real z. the radius value to set is the Real r. the major/minor arc bulge value to set is the Integer b (0 for minor arc < 180 degrees, non zero for major arc > 180 degrees). If the Element super is not of type Super, then the function return value is set to a non zero value. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_super_data",
@@ -16530,7 +16498,7 @@
         "type": "Integer"
       }
     ],
-    "description": "In earlier versions of 12d Model, there were a large number of string types but in later versions of 12d Model, the super string was introduced which with its possible dimensions, could replace many of the other strings. However, for some applications it was important to know if the super string was like one of the original strings. For example, some options required a string to be a contours string, the original 2d string. That is, the string has the one z-value (or height) for the entire string. So a super string that has a constant dimension for height, behaves like a 2d string and in that case will return the Type Like of 2d. The Type Like\u2019s can be referred to by a number (Integer) or by text (Text). See 5.36.1 Types of Elements for the values of the Type Like numbers and Type Like text. The Type Like for the super string is returned in type. If the Element string is not a super string, then a non zero function return value is returned. A function return value of zero indicates the Type Like was returned successfully."
+    "description": "In earlier versions of 12d Model, there were a large number of string types but in later versions of 12d Model, the super string was introduced which with its possible dimensions, could replace many of the other strings. However, for some applications it was important to know if the super string was like one of the original strings. For example, some options required a string to be a contours string, the original 2d string. That is, the string has the one z-value (or height) for the entire string. So a super string that has a constant dimension for height, behaves like a 2d string and in that case will return the Type Like of 2d. The Type Like’s can be referred to by a number (Integer) or by text (Text). See 5.36.1 Types of Elements for the values of the Type Like numbers and Type Like text. The Type Like for the super string is returned in type. If the Element string is not a super string, then a non zero function return value is returned. A function return value of zero indicates the Type Like was returned successfully."
   },
   {
     "name": "Get_type_like",
@@ -16562,7 +16530,7 @@
         "type": "Text"
       }
     ],
-    "description": "In earlier versions of 12d Model, there were a large number of string types but in later versions of 12d Model, the super string was introduced which with its possible dimensions, could replace many of the other strings. However, for some applications it was important to know if the super string was like one of the original strings. For example, some options required a string to be a contours string, the original 2d string. That is, the string has the one z-value (or height) for the entire string. So a super string that has a constant dimension for height, behaves like a 2d string and in that case will return the Type Like of 2d. The Type Like\u2019s can be referred to by a number (Integer) or by text (Text). See 5.36.1 Types of Elements for the values of the Type Like numbers and Type Like text. The Text Type Like for the super string is returned in type. Super String Element Page 413 12d Model Macro Manual If the Element string is not a super string, then a non zero function return value is returned. A function return value of zero indicates the Type Like was returned successfully."
+    "description": "In earlier versions of 12d Model, there were a large number of string types but in later versions of 12d Model, the super string was introduced which with its possible dimensions, could replace many of the other strings. However, for some applications it was important to know if the super string was like one of the original strings. For example, some options required a string to be a contours string, the original 2d string. That is, the string has the one z-value (or height) for the entire string. So a super string that has a constant dimension for height, behaves like a 2d string and in that case will return the Type Like of 2d. The Type Like’s can be referred to by a number (Integer) or by text (Text). See 5.36.1 Types of Elements for the values of the Type Like numbers and Type Like text. The Text Type Like for the super string is returned in type. Super String Element Page 413 12d Model Macro Manual If the Element string is not a super string, then a non zero function return value is returned. A function return value of zero indicates the Type Like was returned successfully."
   },
   {
     "name": "Get_type_like",
@@ -16610,7 +16578,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension height dimension Att_ZCoord_Value exists for the super string super. See Height Dimensions for information on Height dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists, or 0 if the dimension doesn\u2019t exist. If the Element super is not a super string, then a non zero function return value is returned. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension height dimension Att_ZCoord_Value exists for the super string super. See Height Dimensions for information on Height dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists, or 0 if the dimension doesn’t exist. If the Element super is not a super string, then a non zero function return value is returned. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_3d_level",
@@ -16734,7 +16702,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Tinable_Value exists for the super string super. See Tinability Dimensions for information on the Tinability dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Tinable_Value exists for the super string super. See Tinability Dimensions for information on the Tinability dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_vertex_tinability_array",
@@ -16766,7 +16734,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Tinable_Array exists for the super string super. See Tinability Dimensions for information on the Tinability dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Tinable_Array exists for the super string super. See Tinability Dimensions for information on the Tinability dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_vertex_tinability",
@@ -16838,7 +16806,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Tinable_Value exists for the super string super. If Att_Segment_Tinable_Value is set and Att_Segment_Tinability_Array is not set then the tinability is the same for all segments of super. See Tinability Dimensions for information on the Tinability dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Tinable_Value exists for the super string super. If Att_Segment_Tinable_Value is set and Att_Segment_Tinability_Array is not set then the tinability is the same for all segments of super. See Tinability Dimensions for information on the Tinability dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_segment_tinability_array",
@@ -16870,7 +16838,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Tinable_Array exists for the super string super. If Att_Segment_Tinable_Array is set then there can be a different tinability defined for each segment in super. See Tinability Dimensions for information on the Tinability dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Tinable_Array exists for the super string super. If Att_Segment_Tinable_Array is set then there can be a different tinability defined for each segment in super. See Tinability Dimensions for information on the Tinability dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_segment_tinability",
@@ -16942,7 +16910,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the segment radius dimension Att_Radius_Array exists for the super string. use is returned as 1 if the dimension Att_Radius_Array exists, or 0 if the dimension doesn\u2019t exist. See Segment Radius Dimension for information on the Segment Radius dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the segment radius dimension Att_Radius_Array exists for the super string. use is returned as 1 if the dimension Att_Radius_Array exists, or 0 if the dimension doesn’t exist. See Segment Radius Dimension for information on the Segment Radius dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_segment_radius",
@@ -17054,7 +17022,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the segment radius dimension Att_Segment_Linestyle_Array exists for the super string. use is returned as 1 if the dimension Att_Segment_Linestyle_Array exists, or 0 if the dimension doesn\u2019t exist. See Segment Linestyle Dimension for information on the Segment Radius dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the segment radius dimension Att_Segment_Linestyle_Array exists for the super string. use is returned as 1 if the dimension Att_Segment_Linestyle_Array exists, or 0 if the dimension doesn’t exist. See Segment Linestyle Dimension for information on the Segment Radius dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_segment_linestyle",
@@ -17126,7 +17094,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Point_Array exists for the super string. If Att_Point_Array exists, the string can have a Point Id for each vertex. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. See Point Id Dimension for information on the Point Id dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Point_Array exists for the super string. If Att_Point_Array exists, the string can have a Point Id for each vertex. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. See Point Id Dimension for information on the Point Id dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_vertex_point_number",
@@ -17146,7 +17114,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the Element super which must be of type Super, set the Point Id for vertex number vert to the have the text value of the integer point_number. If the Element super is not of type Super, or the dimension Att_Point_Array is not set, then a non- zero return code is returned. See Point Id Dimension for information on the Point Id dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. Note - in earlier versions of 12d Model (pre v6), point id\u2019s were only integers. This was extended to being a text when surveying equipment allowed non-integer point ids. A function return value of zero indicates the point id was successfully set. Page 430 Super String Element Chapter 5 12dPL Library Calls"
+    "description": "For the Element super which must be of type Super, set the Point Id for vertex number vert to the have the text value of the integer point_number. If the Element super is not of type Super, or the dimension Att_Point_Array is not set, then a non- zero return code is returned. See Point Id Dimension for information on the Point Id dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. Note - in earlier versions of 12d Model (pre v6), point id’s were only integers. This was extended to being a text when surveying equipment allowed non-integer point ids. A function return value of zero indicates the point id was successfully set. Page 430 Super String Element Chapter 5 12dPL Library Calls"
   },
   {
     "name": "Get_super_vertex_point_number",
@@ -17166,7 +17134,7 @@
         "type": "Integer"
       }
     ],
-    "description": "This function should no longer be used because now Point Id\u2019s do not have to be integers. From the Element super which must be of type Super, get the Point Id for vertex number vert and return it in the Integer point_number. If the Element super is not of type Super, or the dimension Att_Point_Array is not set for super, then a non-zero return code is returned. See Point Id Dimension for information on the Point Id dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. Note - in earlier versions of 12d Model (pre v6), Point Id\u2019s were only integers. This was extended to being a text when surveying equipment allowed non-integer Point Ids. A function return value of zero indicates the point id was successfully returned."
+    "description": "This function should no longer be used because now Point Id’s do not have to be integers. From the Element super which must be of type Super, get the Point Id for vertex number vert and return it in the Integer point_number. If the Element super is not of type Super, or the dimension Att_Point_Array is not set for super, then a non-zero return code is returned. See Point Id Dimension for information on the Point Id dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. Note - in earlier versions of 12d Model (pre v6), Point Id’s were only integers. This was extended to being a text when surveying equipment allowed non-integer Point Ids. A function return value of zero indicates the point id was successfully returned."
   },
   {
     "name": "Get_super_vertex_point_number",
@@ -17218,7 +17186,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the vertex symbol dimension Att_Symbol_Value exists for the Element super of type Super. See Vertex Symbol Dimensions for information on the Vertex Symbol dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists. That is, the super string has one symbol for all vertices. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the vertex symbol dimension Att_Symbol_Value exists for the Element super of type Super. See Vertex Symbol Dimensions for information on the Vertex Symbol dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists. That is, the super string has one symbol for all vertices. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_vertex_symbol",
@@ -17478,7 +17446,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the pipe/culvert dimension Att_Culvert_Value exists for the super string. See Pipe/Culvert Dimensions for information on the Pipe/Culvert dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension Att_Culvert_Value exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the pipe/culvert dimension Att_Culvert_Value exists for the super string. See Pipe/Culvert Dimensions for information on the Pipe/Culvert dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension Att_Culvert_Value exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_segment_culvert",
@@ -17510,7 +17478,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the pipe/culvert dimension Att_Culvert_Array exists for the super string. See Pipe/Culvert Dimensions for information on the Pipe/Culvert dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension Att_Culvert_Array exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the pipe/culvert dimension Att_Culvert_Array exists for the super string. See Pipe/Culvert Dimensions for information on the Pipe/Culvert dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension Att_Culvert_Array exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_pipe_justify",
@@ -17542,7 +17510,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the pipe/culvert dimension Att_Pipe_Justify exists for the Element super of type Super. See Pipe/Culvert Dimensions for information on the Pipe/Culvert dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists use is returned as 0 if the dimension doesn\u2019t exist. Note: the same justification flag is used whether the super string is a round pipe or a culvert and the justification applies for the entire string. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the pipe/culvert dimension Att_Pipe_Justify exists for the Element super of type Super. See Pipe/Culvert Dimensions for information on the Pipe/Culvert dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists use is returned as 0 if the dimension doesn’t exist. Note: the same justification flag is used whether the super string is a round pipe or a culvert and the justification applies for the entire string. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_pipe_justify",
@@ -17922,7 +17890,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Text_Value exists for the super string super. use is returned as 1 if the dimension Att_Vertex_Text_Value exists. use is returned as 0 if the dimension doesn\u2019t exist. If the dimension Att_Vertex_Text_Value exists then the string has the same text for every vertex of the string. See Vertex Text Dimensions for information on the Text dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Text_Value exists for the super string super. use is returned as 1 if the dimension Att_Vertex_Text_Value exists. use is returned as 0 if the dimension doesn’t exist. If the dimension Att_Vertex_Text_Value exists then the string has the same text for every vertex of the string. See Vertex Text Dimensions for information on the Text dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_vertex_text_array",
@@ -17954,7 +17922,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Text_Array exists (is used) for the super string super. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. If Att_Vertex_Text_Array is used, then there is different text on each vertex of the of the string. See Vertex Text Dimensions for information on the Text dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Text_Array exists (is used) for the super string super. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. If Att_Vertex_Text_Array is used, then there is different text on each vertex of the of the string. See Vertex Text Dimensions for information on the Text dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Super_vertex_text_value_to_array",
@@ -17982,7 +17950,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Tell the super string super whether to use, or not use, the dimension Att_Vertex_Annotate_Value. If the dimension Att_Vertex_Annotate_Value exists and the dimension Att_Vertex_Annotate_Array doesn\u2019t exist then the string has the one annotation which is used for vertex text on any vertex of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A value for use of 1 sets the dimension and 0 removes it. Note if the dimension Att_Vertex_Annotate_Array exists, this call is ignored. A return value of 0 indicates the function call was successful."
+    "description": "Tell the super string super whether to use, or not use, the dimension Att_Vertex_Annotate_Value. If the dimension Att_Vertex_Annotate_Value exists and the dimension Att_Vertex_Annotate_Array doesn’t exist then the string has the one annotation which is used for vertex text on any vertex of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A value for use of 1 sets the dimension and 0 removes it. Note if the dimension Att_Vertex_Annotate_Array exists, this call is ignored. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Get_super_use_vertex_annotation_value",
@@ -17998,7 +17966,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Annotate_Value exists for the super string super. If the dimension Att_Vertex_Annotate_Value exists and the dimension Att_Vertex_Annotate_Array doesn\u2019t exist then the string has the one annotation which is used for vertex text on any vertex of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Annotate_Value exists for the super string super. If the dimension Att_Vertex_Annotate_Value exists and the dimension Att_Vertex_Annotate_Array doesn’t exist then the string has the one annotation which is used for vertex text on any vertex of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_vertex_annotation_array",
@@ -18030,7 +17998,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Annotate_Array exists for the super string super. If the dimension Att_Vertex_Annotate_Array exists then the string has a different annotation for the vertex text on each vertex of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Annotate_Array exists for the super string super. If the dimension Att_Vertex_Annotate_Array exists then the string has a different annotation for the vertex text on each vertex of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Super_vertex_annotate_value_to_array",
@@ -18592,6 +18560,10 @@
       {
         "name": "vert",
         "type": "Integer"
+      },
+      {
+        "name": "underline",
+        "type": "Integer"
       }
     ],
     "description": "For the Element super of type Super, get the underline state for the vertex text on vertex number vert and return it as underline. If underline = 1, then for a true type font the text will be underlined. If underline = 0, then text will not be underlined. If there is only one Vertex Text Annotation for all the Vertex Text then the underline state for that one Vertex Text Annotation will be returned in underline regardless of the value of vert. A non-zero function return value is returned if super is not of type Super, or if super does not have the dimension Att_Vertex_Text_Array or Att_Vertex_Value set. A function return value of zero indicates underline was successfully returned."
@@ -18627,6 +18599,10 @@
       },
       {
         "name": "vert",
+        "type": "Integer"
+      },
+      {
+        "name": "strikeout",
         "type": "Integer"
       }
     ],
@@ -18922,7 +18898,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Text_Value exists for the super string. use is returned as 1 if the dimension Att_Segment_Text_Value exists. use is returned as 0 if the dimension doesn\u2019t exist. If the dimension Att_Segment_Text_Value exists then the string has the same text for every segment of the string. See Segment Text Dimensions for information on the Segment Text dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Text_Value exists for the super string. use is returned as 1 if the dimension Att_Segment_Text_Value exists. use is returned as 0 if the dimension doesn’t exist. If the dimension Att_Segment_Text_Value exists then the string has the same text for every segment of the string. See Segment Text Dimensions for information on the Segment Text dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_segment_text_array",
@@ -18954,7 +18930,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Text_Array exists for the super string super. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. If Att_Segment_Text_Array is used, then there is different text on each segment of the of the string. See Segment Text Dimensions for information on the Text dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Text_Array exists for the super string super. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. If Att_Segment_Text_Array is used, then there is different text on each segment of the of the string. See Segment Text Dimensions for information on the Text dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Super_segment_text_value_to_array",
@@ -18982,7 +18958,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Tell the super string whether to use or remove, the dimension Att_Segment_Annotate_Value. If the dimension Att_Segment_Annotate_Value exists and the dimension Att_Segment_Annotate_Array doesn\u2019t exist then the string has the one annotation which is used for segment text on any segment of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A value for use of 1 sets the dimension and 0 removes it. Note if the dimension Att_Segment_Annotate_Array exists, this call is ignored. A non-zero function return value is returned if super is not of type Super. A return value of 0 indicates the function call was successful."
+    "description": "Tell the super string whether to use or remove, the dimension Att_Segment_Annotate_Value. If the dimension Att_Segment_Annotate_Value exists and the dimension Att_Segment_Annotate_Array doesn’t exist then the string has the one annotation which is used for segment text on any segment of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. A value for use of 1 sets the dimension and 0 removes it. Note if the dimension Att_Segment_Annotate_Array exists, this call is ignored. A non-zero function return value is returned if super is not of type Super. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Get_super_use_segment_annotation_value",
@@ -18998,7 +18974,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Annotate_Value exists for the super string. If the dimension Att_Segment_Annotate_Value exists and the dimension Att_Segment_Annotate_Array doesn\u2019t exist then the string has the one annotation which is used for segment text on any segment of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A non-zero function return value is returned if super is not of type Super. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Annotate_Value exists for the super string. If the dimension Att_Segment_Annotate_Value exists and the dimension Att_Segment_Annotate_Array doesn’t exist then the string has the one annotation which is used for segment text on any segment of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A non-zero function return value is returned if super is not of type Super. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_segment_annotation_array",
@@ -19030,7 +19006,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Annotate_Array exists for the super string. If the dimension Att_Segment_Annotate_Array exists then the string has a different annotation for the segment text on each segment of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A non-zero function return value is returned if super is not of type Super. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Annotate_Array exists for the super string. If the dimension Att_Segment_Annotate_Array exists then the string has a different annotation for the segment text on each segment of the string. See Vertex Text Annotation Dimensions for information on the Text Annotation dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A non-zero function return value is returned if super is not of type Super. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Super_segment_annotate_value_to_array",
@@ -19544,6 +19520,10 @@
       {
         "name": "seg",
         "type": "Integer"
+      },
+      {
+        "name": "underline",
+        "type": "Integer"
       }
     ],
     "description": "For the super string super, set the underline state of the segment text on segment number seg to underline. If underline = 1, then for a true type font the text will be underlined. If underline = 0, then text will not be underlined. For a diagram, see 5.9 Textstyle Data. If there is only one Segment Text Annotation for all the Segment Text then the underline state for that one Segment Text Annotation is set to underline regardless of the value of seg. A non-zero function return value is returned if super is not of type Super. A function return value of zero indicates underline was successfully set."
@@ -19559,6 +19539,10 @@
       },
       {
         "name": "seg",
+        "type": "Integer"
+      },
+      {
+        "name": "underline",
         "type": "Integer"
       }
     ],
@@ -19595,6 +19579,10 @@
       },
       {
         "name": "seg",
+        "type": "Integer"
+      },
+      {
+        "name": "strikeout",
         "type": "Integer"
       }
     ],
@@ -19890,7 +19878,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Hatch_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists and hatching is enabled for the string. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Hatch_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists and hatching is enabled for the string. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_hatch_colour",
@@ -20174,7 +20162,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Solid_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists and solid fill is enabled for the string. use is returned as 0 if the dimension doesn\u2019t exist. A return value of zero indicates the function call was successful."
+    "description": "Query whether the dimension Att_Solid_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists and solid fill is enabled for the string. use is returned as 0 if the dimension doesn’t exist. A return value of zero indicates the function call was successful."
   },
   {
     "name": "Set_super_solid_colour",
@@ -20270,7 +20258,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Bitmap_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists and bitmap fill is enabled for the string. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Bitmap_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists and bitmap fill is enabled for the string. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_bitmap",
@@ -20650,7 +20638,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Pattern_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Pattern_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_pattern",
@@ -21050,7 +21038,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Autocad_Pattern_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Autocad_Pattern_Value exists for the super string super. See Solid/Bitmap/Hatch/ Fill/Pattern/ACAD Pattern Dimensions for information on this dimension or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_acad_pattern",
@@ -21294,7 +21282,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Hole_Value exists for the super string super. See Hole Dimension for information on hole dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Hole_Value exists for the super string super. See Hole Dimension for information on hole dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Super_get_hole",
@@ -21378,7 +21366,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the colour dimension Att_Colour_Array exists for the super string. use is returned as 1 if the dimension Att_Colour_Array exists, or 0 if the dimension doesn\u2019t exist. See Colour Dimension for information on Colour dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the colour dimension Att_Colour_Array exists for the super string. use is returned as 1 if the dimension Att_Colour_Array exists, or 0 if the dimension doesn’t exist. See Colour Dimension for information on Colour dimensions or 5.38.1 Super String Dimensionsfor information on all dimensions. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_segment_colour",
@@ -21430,7 +21418,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Geom_Array exists for the super string super. If Att_Geom_Array exists, the string can have Segments (which can be straights, arcs or transitions) between the vertices of the super string. See Segment Geometry Dimension for information on the Segment Geometry dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. That is, the segments of the super string are not just straights but of type Segments (which can be straights, arcs or transitions). use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Geom_Array exists for the super string super. If Att_Geom_Array exists, the string can have Segments (which can be straights, arcs or transitions) between the vertices of the super string. See Segment Geometry Dimension for information on the Segment Geometry dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. That is, the segments of the super string are not just straights but of type Segments (which can be straights, arcs or transitions). use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_segment_spiral",
@@ -21630,6 +21618,10 @@
     "returnType": "Integer",
     "parameters": [
       {
+        "name": "element",
+        "type": "Element"
+      },
+      {
         "name": "seg",
         "type": "Integer"
       },
@@ -21670,7 +21662,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Extrude_Value exists for the super string super. If Att_Extrude_Value is set then an extrusion is allowed on the super string. See Extrude Dimensions for information on the Extrude dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Extrude_Value exists for the super string super. If Att_Extrude_Value is set then an extrusion is allowed on the super string. See Extrude Dimensions for information on the Extrude dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Super_append_string_extrude",
@@ -21862,7 +21854,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Interval_Value exists for the super string super. If Att_Interval_Value is set then there is a Real interval_distance and a Real chord_arc_distance stored for the super string. See Interval Dimensions for information on the Extrude dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Interval_Value exists for the super string super. If Att_Interval_Value is set then there is a Real interval_distance and a Real chord_arc_distance stored for the super string. See Interval Dimensions for information on the Extrude dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_interval_distance",
@@ -21942,7 +21934,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Attribute_Array exists for the super string. If Att_Vertex_Attribute_Array exists then there can be a type Attributes for each vertex. See User Defined Vertex Attributes Dimensions for information on the Attributes dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Attribute_Array exists for the super string. If Att_Vertex_Attribute_Array exists then there can be a type Attributes for each vertex. See User Defined Vertex Attributes Dimensions for information on the Attributes dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_vertex_attributes",
@@ -22078,7 +22070,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the Element super and on the vertex number vert,\uf020 if the attribute called att_name does not exist then create it as type Uid and give it the value uid.\uf020 if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element super and on the vertex number vert, if the attribute called att_name does not exist then create it as type Uid and give it the value uid. if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_super_vertex_attribute",
@@ -22550,7 +22542,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Element super and on the vertex number vert,\uf020 if the attribute called att_name does not exist then create it as type Text and give it the value txt.\uf020 if the attribute called att_name does exist and it is type Text, then set its value to txt. Super String Element Page 553 12d Model Macro Manual If the attribute exists and is not of type Text then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element super and on the vertex number vert, if the attribute called att_name does not exist then create it as type Text and give it the value txt. if the attribute called att_name does exist and it is type Text, then set its value to txt. Super String Element Page 553 12d Model Macro Manual If the attribute exists and is not of type Text then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_super_vertex_attribute",
@@ -22574,7 +22566,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the Element super and on the vertex number vert,\uf020 if the attribute called att_name does not exist then create it as type Integer and give it the value int.\uf020 if the attribute called att_name does exist and it is type Integer, then set its value to int. If the attribute exists and is not of type Integer then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element super and on the vertex number vert, if the attribute called att_name does not exist then create it as type Integer and give it the value int. if the attribute called att_name does exist and it is type Integer, then set its value to int. If the attribute exists and is not of type Integer then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_super_vertex_attribute",
@@ -22598,7 +22590,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the Element super and on the vertex number vert,\uf020 if the attribute called att_name does not exist then create it as type Real and give it the value real.\uf020 if the attribute called att_name does exist and it is type Real, then set its value to real. If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element super and on the vertex number vert, if the attribute called att_name does not exist then create it as type Real and give it the value real. if the attribute called att_name does exist and it is type Real, then set its value to real. If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_super_vertex_attribute",
@@ -22622,7 +22614,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Element super and on the vertex number vert,\uf020 if the attribute with number att_no does not exist then create it as type Text and give it the value txt.\uf020 if the attribute with number att_no does exist and it is type Text, then set its value to txt. If the attribute exists and is not of type Text then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute number att_no."
+    "description": "For the Element super and on the vertex number vert, if the attribute with number att_no does not exist then create it as type Text and give it the value txt. if the attribute with number att_no does exist and it is type Text, then set its value to txt. If the attribute exists and is not of type Text then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute number att_no."
   },
   {
     "name": "Set_super_vertex_attribute",
@@ -22646,7 +22638,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the Element super and on the vertex number vert,\uf020 if the attribute with number att_no does not exist then create it as type Integer and give it the value int.\uf020 if the attribute with number att_no does exist and it is type Integer, then set its value to int. If the attribute exists and is not of type Integer then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute number att_no."
+    "description": "For the Element super and on the vertex number vert, if the attribute with number att_no does not exist then create it as type Integer and give it the value int. if the attribute with number att_no does exist and it is type Integer, then set its value to int. If the attribute exists and is not of type Integer then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute number att_no."
   },
   {
     "name": "Set_super_vertex_attribute",
@@ -22670,7 +22662,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the Element super and on the vertex number vert,\uf020 if the attribute with number att_no does not exist then create it as type Real and give it the value real.\uf020 if the attribute with number att_no does exist and it is type Real, then set its value to real. If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute number att_no."
+    "description": "For the Element super and on the vertex number vert, if the attribute with number att_no does not exist then create it as type Real and give it the value real. if the attribute with number att_no does exist and it is type Real, then set its value to real. If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute number att_no."
   },
   {
     "name": "Set_super_use_segment_attribute",
@@ -22702,7 +22694,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Attribute_Array exists for the super string. If the dimension Att_Segment_Attribute_Array exists then there can be an Attributes on each segment. See User Defined Vertex Attributes Dimensions for information on the Attributes dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Attribute_Array exists for the super string. If the dimension Att_Segment_Attribute_Array exists then there can be an Attributes on each segment. See User Defined Vertex Attributes Dimensions for information on the Attributes dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Get_super_segment_attributes",
@@ -22832,6 +22824,10 @@
       {
         "name": "att_no",
         "type": "Integer"
+      },
+      {
+        "name": "att",
+        "type": "Attributes"
       }
     ],
     "description": "For the Element super, get the attribute with number att_no for the segment number seg and return the attribute value in att. The attribute must be of type Attributes. If the Element is not of type Super or the attribute is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully returned. Note - the Get_attribute_type call can be used to get the type of the attribute with attribute number att_no."
@@ -22858,7 +22854,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the Element super and on the segment number seg,\uf020 if the attribute called att_name does not exist then create it as type Uid and give it the value uid.\uf020 if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element super and on the segment number seg, if the attribute called att_name does not exist then create it as type Uid and give it the value uid. if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_super_segment_attribute",
@@ -22876,9 +22872,13 @@
       {
         "name": "att_name",
         "type": "Text"
+      },
+      {
+        "name": "att",
+        "type": "Attributes"
       }
     ],
-    "description": "For the Element super and on the segment number seg,\uf020 if the attribute called att_name does not exist then create it as type Attributes and give it the value att.\uf020 Page 558 Super String Element Chapter 5 12dPL Library Calls if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element super and on the segment number seg, if the attribute called att_name does not exist then create it as type Attributes and give it the value att. Page 558 Super String Element Chapter 5 12dPL Library Calls if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_super_segment_attribute",
@@ -23062,7 +23062,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the Element super and on the segment number seg,\uf020 if the attribute with number att_no does not exist then create it as type Real and give it the value real.\uf020 if the attribute with number att_no does exist and it is type Real, then set its value to real. If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute number att_no."
+    "description": "For the Element super and on the segment number seg, if the attribute with number att_no does not exist then create it as type Real and give it the value real. if the attribute with number att_no does exist and it is type Real, then set its value to real. If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute number att_no."
   },
   {
     "name": "Set_super_use_vertex_uid",
@@ -23094,7 +23094,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_UID_Array exists (is used) for the super string super. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. If Att_Vertex_UID_Array is used, then there is an Integer (referred to as a uid) stored at each vertex of the super string. This is used by 12d Solutions to store special backtracking numbers on each vertex (for example for survey data reduction or with the underlying super string in a super alignment). See UID Dimensions for information on the Vertex UID dimension or 5.38.1 Super String Dimensions for information on all the dimensions."
+    "description": "Query whether the dimension Att_Vertex_UID_Array exists (is used) for the super string super. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. If Att_Vertex_UID_Array is used, then there is an Integer (referred to as a uid) stored at each vertex of the super string. This is used by 12d Solutions to store special backtracking numbers on each vertex (for example for survey data reduction or with the underlying super string in a super alignment). See UID Dimensions for information on the Vertex UID dimension or 5.38.1 Super String Dimensions for information on all the dimensions."
   },
   {
     "name": "Set_super_vertex_uid",
@@ -23166,7 +23166,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_UID_Array exists (is used) for the super string super. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. If Att_Segment_UID_Array is used, then there is an Integer stored at each segment of the super string. This is used by 12d Solutions to store special backtracking numbers on each segment (for example for survey data reduction or with the underlying super string in a super alignment). See UID Dimensions for information on the Segment UID dimension or 5.38.1 Super String Dimensions for information on all the dimensions."
+    "description": "Query whether the dimension Att_Segment_UID_Array exists (is used) for the super string super. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. If Att_Segment_UID_Array is used, then there is an Integer stored at each segment of the super string. This is used by 12d Solutions to store special backtracking numbers on each segment (for example for survey data reduction or with the underlying super string in a super alignment). See UID Dimensions for information on the Segment UID dimension or 5.38.1 Super String Dimensions for information on all the dimensions."
   },
   {
     "name": "Set_super_segment_uid",
@@ -23238,7 +23238,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Image_Value exists for the super string super. If the dimension Att_Vertex_Image_Value is set then there can be one image attached to each vertex. See Vertex Image Dimensions for information on the Vertex Image dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Image_Value exists for the super string super. If the dimension Att_Vertex_Image_Value is set then there can be one image attached to each vertex. See Vertex Image Dimensions for information on the Vertex Image dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_vertex_image_array",
@@ -23270,7 +23270,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Image_Array exists for the super string super. If the dimension Att_Vertex_Image_Array is set then there can be more than one image attached to each vertex. See Vertex Image Dimensions for information on the Vertex Image dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. That is, each super string vertex can have a number of images attached to it. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Image_Array exists for the super string super. If the dimension Att_Vertex_Image_Array is set then there can be more than one image attached to each vertex. See Vertex Image Dimensions for information on the Vertex Image dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. That is, each super string vertex can have a number of images attached to it. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Super_vertex_image_value_to_array",
@@ -23462,7 +23462,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Visible_Array exists for the super string. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Visible_Array exists for the super string. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_vertex_visibility_value",
@@ -23494,7 +23494,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Visible_Value exists for the super string super. If Att_Vertex_Visible_Value is set then there is one visibility value for all vertices in super. If Att_Vertex_Visible_Value is set and Att_Vertex_Visible_Array is not set, then there is only one visibility value for all vertices in super. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Visible_Value exists for the super string super. If Att_Vertex_Visible_Value is set then there is one visibility value for all vertices in super. If Att_Vertex_Visible_Value is set and Att_Vertex_Visible_Array is not set, then there is only one visibility value for all vertices in super. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_vertex_visibility_array",
@@ -23526,7 +23526,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Vertex_Visible_Array exists for the super string super. If Att_Vertex_Visible_Array is set then there can be a different visibility defined for each vertex in super. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Vertex_Visible_Array exists for the super string super. If Att_Vertex_Visible_Array is set then there can be a different visibility defined for each vertex in super. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_vertex_visibility",
@@ -23598,7 +23598,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Visible_Value exists for the super string super. If Att_Segment_Visible_Value is set and Att_Segment_Visible_Array is not set, then the visibility is the same for all segments in super. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Visible_Value exists for the super string super. If Att_Segment_Visible_Value is set and Att_Segment_Visible_Array is not set, then the visibility is the same for all segments in super. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_use_segment_visibility_array",
@@ -23630,7 +23630,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Query whether the dimension Att_Segment_Visible_Array exists for the super string super. If Att_Segment_Visible_Array is set then there can be a different visibility defined for each segment in super. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn\u2019t exist. A return value of 0 indicates the function call was successful."
+    "description": "Query whether the dimension Att_Segment_Visible_Array exists for the super string super. If Att_Segment_Visible_Array is set then there can be a different visibility defined for each segment in super. See Visibility Dimensions for information on the Visibility dimensions or 5.38.1 Super String Dimensions for information on all the dimensions. use is returned as 1 if the dimension exists. use is returned as 0 if the dimension doesn’t exist. A return value of 0 indicates the function call was successful."
   },
   {
     "name": "Set_super_segment_visibility",
@@ -24087,6 +24087,10 @@
       {
         "name": "vert_hori",
         "type": "Integer"
+      },
+      {
+        "name": "ch",
+        "type": "Real"
       },
       {
         "name": "&name",
@@ -24613,7 +24617,7 @@
   },
   {
     "name": "Get_super_alignment_equality_info",
-    "id": 2238,
+    "id": 2223,
     "returnType": "Integer",
     "parameters": [
       {
@@ -24774,54 +24778,6 @@
       }
     ],
     "description": "Arc String Element Page 615 12d Model Macro Manual Create an Element of type Arc with centre (xc,yc,zc), radius rad, start point (xs,ys,zs) and end point (xe,ye,ze). The function return value gives the actual Element created. If the arc string could not be created, then the returned Element will be null."
-  },
-  {
-    "name": "Create_arc",
-    "id": 296,
-    "returnType": "Element",
-    "parameters": [
-      {
-        "name": "xc",
-        "type": "Real"
-      },
-      {
-        "name": "yc",
-        "type": "Real"
-      },
-      {
-        "name": "zc",
-        "type": "Real"
-      },
-      {
-        "name": "rad",
-        "type": "Real"
-      },
-      {
-        "name": "xs",
-        "type": "Real"
-      },
-      {
-        "name": "ys",
-        "type": "Real"
-      },
-      {
-        "name": "zs",
-        "type": "Real"
-      },
-      {
-        "name": "xe",
-        "type": "Real"
-      },
-      {
-        "name": "ye",
-        "type": "Real"
-      },
-      {
-        "name": "ze",
-        "type": "Real"
-      }
-    ],
-    "description": "Create an Element of type Arc with centre (xc,yc,zc), and radius rad. The points (xs,ys,zs) and (xe,ye,ze) define the start and end points respectively for the arc. If either of the points do not lie on the plan circle with centre (xc,yc) and radius rad, then the point is dropped perpendicularly onto the plan circle to define the (x,y) co-ordinates for the relevant start or end point. The function return value gives the actual Element created. If the arc string could not be created, then the returned Element will be null."
   },
   {
     "name": "Create_arc",
@@ -25633,7 +25589,11 @@
         "type": "Integer"
       },
       {
-        "name": "justif",
+        "name": "angle",
+        "type": "Real"
+      },
+      {
+        "name": "justification",
         "type": "Integer"
       },
       {
@@ -25785,7 +25745,7 @@
   },
   {
     "name": "Set_text_xy",
-    "id": 462,
+    "id": 100462,
     "returnType": "Integer",
     "parameters": [
       {
@@ -25805,7 +25765,7 @@
   },
   {
     "name": "Get_text_xy",
-    "id": 454,
+    "id": 100454,
     "returnType": "Integer",
     "parameters": [
       {
@@ -25825,7 +25785,7 @@
   },
   {
     "name": "Set_text_xyz",
-    "id": 462,
+    "id": 3216,
     "returnType": "Integer",
     "parameters": [
       {
@@ -25849,7 +25809,7 @@
   },
   {
     "name": "Get_text_xyz",
-    "id": 454,
+    "id": 3215,
     "returnType": "Integer",
     "parameters": [
       {
@@ -26482,14 +26442,14 @@
   {
     "name": "Create_pipeline",
     "id": 1264,
-    "returnType": "Integer",
+    "returnType": "Element",
     "parameters": [],
     "description": "Create a pipeline. A function return value of zero indicates the pipeline was created successfully."
   },
   {
     "name": "Create_pipeline",
     "id": 1265,
-    "returnType": "Integer",
+    "returnType": "Element",
     "parameters": [
       {
         "name": "seed",
@@ -26784,7 +26744,7 @@
     "returnType": "Integer",
     "parameters": [
       {
-        "name": "drain",
+        "name": "element",
         "type": "Element"
       },
       {
@@ -26802,6 +26762,10 @@
       {
         "name": "r[]",
         "type": "Real"
+      },
+      {
+        "name": "b[]",
+        "type": "Integer"
       },
       {
         "name": "num_verts",
@@ -27242,6 +27206,10 @@
       {
         "name": "ip",
         "type": "Integer"
+      },
+      {
+        "name": "dist",
+        "type": "Real"
       }
     ],
     "description": "Insert a new node (pit) of given index ip to the drainage string Element element."
@@ -27260,7 +27228,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the Element drain, which must of type Drainage, get the number of pits for the string and return it in npits. The number of pipes in npits - 1. The i\u2019th pipe goes from the i\u2019th pit to the (i+1)\u2019th pit. If drain is not an Element of type Drainage then a non zero function return code is returned. A function return value of zero indicates the data was successfully returned."
+    "description": "For the Element drain, which must of type Drainage, get the number of pits for the string and return it in npits. The number of pipes in npits - 1. The i’th pipe goes from the i’th pit to the (i+1)’th pit. If drain is not an Element of type Drainage then a non zero function return code is returned. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_pit",
@@ -27468,7 +27436,7 @@
   },
   {
     "name": "Set_drainage_pit_width",
-    "id": 2876,
+    "id": 2877,
     "returnType": "Integer",
     "parameters": [
       {
@@ -27488,7 +27456,7 @@
   },
   {
     "name": "Get_drainage_pit_width",
-    "id": 2877,
+    "id": 2876,
     "returnType": "Integer",
     "parameters": [
       {
@@ -27508,7 +27476,7 @@
   },
   {
     "name": "Set_drainage_pit_length",
-    "id": 2878,
+    "id": 2879,
     "returnType": "Integer",
     "parameters": [
       {
@@ -27528,7 +27496,7 @@
   },
   {
     "name": "Get_drainage_pit_length",
-    "id": 2879,
+    "id": 2878,
     "returnType": "Integer",
     "parameters": [
       {
@@ -28378,6 +28346,10 @@
       {
         "name": "extended",
         "type": "Integer"
+      },
+      {
+        "name": "adjust_pit_con_points",
+        "type": "Integer"
       }
     ],
     "description": "For the Element drain, which must of type Drainage, set the extennded type for the pth pit to extended. The list of valid type is 0 - not extended 1 - extended in the width direction 2 - extended in the length direction If adjust_pit_con_points is not zero, recalculate the pit connection points for the pit after the extended type being set. If drain is not an Element of type Drainage then a non zero function return code is returned. A function return value of zero indicates the data was successfully set."
@@ -28868,7 +28840,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get the name of the i\u2019th manhole type from the drainage.4d file and return the name in type. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the name of the i’th manhole type from the drainage.4d file and return the name in type. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Get_drainage_manhole_length",
@@ -29124,7 +29096,7 @@
         "type": "Text"
       }
     ],
-    "description": "From the drainage.4d file, for the manhole of type type, return the name of the i\u2019th grade curve (cap_curve_grade) in name. A function return value of zero indicates the name was successfully returned."
+    "description": "From the drainage.4d file, for the manhole of type type, return the name of the i’th grade curve (cap_curve_grade) in name. A function return value of zero indicates the name was successfully returned."
   },
   {
     "name": "Get_drainage_manhole_capacities_grade",
@@ -30256,7 +30228,7 @@
         "type": "Dynamic_Element"
       }
     ],
-    "description": "For the Element drain, which must be of type Drainage, return as super strings, the shape of the insides of the pipes in the Dynamic_Element super_inside and the shape of the outsides of the pipes in the Dynamic_Element super_outside. The number of pipes, separation and thickness settings are used in generating all the shapes. So this function returns a list of the super strings that \u201cdraw\u201d the plan view of the inside and outside of the pipes. For a circular pipe with wall thickness, the super_inside string is a super string with a plan box shape with a width of the diameter of the pipe and a length equal to the length of the pipe. And super_outside has a width equal to (diameter + 2*thickness). For a rectangular pipe with a wall thicknesses, the super_inside is a super string with a plan box shape with a width of the diameter of the pipe and a length equal to the length of the pipe. And super_outside has a width equal to (diameter + left_thickness + right_thickness) mode controls the z values assigned to the super strings. If mode = 0, the shapes are given the z-value of the invert levels of the pipes. If mode = 1, the shapes are given the z-value of the centre levels of the pipes. If mode = 2, the shapes are given the z-value of the obvert levels of the pipes. A function return value of 2 indicates the super strings could not be created. A function return value of zero indicates the shapes were successfully returned."
+    "description": "For the Element drain, which must be of type Drainage, return as super strings, the shape of the insides of the pipes in the Dynamic_Element super_inside and the shape of the outsides of the pipes in the Dynamic_Element super_outside. The number of pipes, separation and thickness settings are used in generating all the shapes. So this function returns a list of the super strings that “draw” the plan view of the inside and outside of the pipes. For a circular pipe with wall thickness, the super_inside string is a super string with a plan box shape with a width of the diameter of the pipe and a length equal to the length of the pipe. And super_outside has a width equal to (diameter + 2*thickness). For a rectangular pipe with a wall thicknesses, the super_inside is a super string with a plan box shape with a width of the diameter of the pipe and a length equal to the length of the pipe. And super_outside has a width equal to (diameter + left_thickness + right_thickness) mode controls the z values assigned to the super strings. If mode = 0, the shapes are given the z-value of the invert levels of the pipes. If mode = 1, the shapes are given the z-value of the centre levels of the pipes. If mode = 2, the shapes are given the z-value of the obvert levels of the pipes. A function return value of 2 indicates the super strings could not be created. A function return value of zero indicates the shapes were successfully returned."
   },
   {
     "name": "Get_drainage_pipe_shape",
@@ -30288,7 +30260,7 @@
         "type": "Element"
       }
     ],
-    "description": "For the Element drain, which must be of type Drainage, return the shape of the inside of pipe number pipe as the super string super_inside and the shape of the outside of the pipe as super_outside, and the shapes are offset in the (x,y) plane from the pipe by the distance offset. If offset is positive then the shapes are offset to the right of the pipe and to the left when the offset is negative. Left and right is defined with respect to the direction of the pipe. So this function returns a list of the super strings that \u201cdraw\u201d the plan view of the inside and outside Drainage String Element Page 711 12d Model Macro Manual of the pipe offset by the given value offset. For for a circular pipe with a wall thickness, the super_inside is a super string with a plan box shape with a width of the diameter of the pipe and a length equal to the length of the pipe. And super_outside has a width equal to (diameter + 2*thickness). For a rectangular pipe with a wall thicknesses, the super_inside is a super string with a plan box shape with a width of the diameter of the pipe and a length equal to the length of the pipe. And super_outside has a width equal to (diameter + left_thickness + right_thickness) If mode = 0, the shapes are given the z-value of the invert levels of the pipe. If mode = 1, the shapes are given the z-value of the centre levels of the pipe. If mode = 2, the shapes are given the z-value of the obvert levels of the pipe. If drain is not an Element of type Drainage then a non zero function return code is returned. A function return value of zero indicates the shapes were successfully returned. Note: the number of pipes and separation are not used for generating the shapes and offset is use instead. For generating shapes using number of pipes and separation, see Get_drainage_pipe_shape(Element element,Integer pipe,Integer mode,Dynamic_Element &super_inside,Dynamic_Element &super_outside)"
+    "description": "For the Element drain, which must be of type Drainage, return the shape of the inside of pipe number pipe as the super string super_inside and the shape of the outside of the pipe as super_outside, and the shapes are offset in the (x,y) plane from the pipe by the distance offset. If offset is positive then the shapes are offset to the right of the pipe and to the left when the offset is negative. Left and right is defined with respect to the direction of the pipe. So this function returns a list of the super strings that “draw” the plan view of the inside and outside Drainage String Element Page 711 12d Model Macro Manual of the pipe offset by the given value offset. For for a circular pipe with a wall thickness, the super_inside is a super string with a plan box shape with a width of the diameter of the pipe and a length equal to the length of the pipe. And super_outside has a width equal to (diameter + 2*thickness). For a rectangular pipe with a wall thicknesses, the super_inside is a super string with a plan box shape with a width of the diameter of the pipe and a length equal to the length of the pipe. And super_outside has a width equal to (diameter + left_thickness + right_thickness) If mode = 0, the shapes are given the z-value of the invert levels of the pipe. If mode = 1, the shapes are given the z-value of the centre levels of the pipe. If mode = 2, the shapes are given the z-value of the obvert levels of the pipe. If drain is not an Element of type Drainage then a non zero function return code is returned. A function return value of zero indicates the shapes were successfully returned. Note: the number of pipes and separation are not used for generating the shapes and offset is use instead. For generating shapes using number of pipes and separation, see Get_drainage_pipe_shape(Element element,Integer pipe,Integer mode,Dynamic_Element &super_inside,Dynamic_Element &super_outside)"
   },
   {
     "name": "Set_drainage_pipe_hgls",
@@ -30556,7 +30528,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get the name of the i\u2019th pipe type (class) from the drainage.4d file and return the name in type. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the name of the i’th pipe type (class) from the drainage.4d file and return the name in type. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Get_drainage_pipe_roughness",
@@ -30677,7 +30649,7 @@
       },
       {
         "name": "&att",
-        "type": "Attributes\uf020"
+        "type": "Attributes"
       }
     ],
     "description": "For the Element drain, get the attribute called att_name for the pipe number pipe and return the attribute value in att. The attribute must be of type Attributes. If the Element is not of type Drainage or the attribute is not of type Attributes then a non-zero Page 718 Drainage String Element Chapter 5 12dPL Library Calls return value is returned. A function return value of zero indicates the attribute value is successfully returned. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
@@ -30752,7 +30724,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the Element drain and on the pipe number pipe,\uf020 if the attribute called att_name does not exist then create it as type Uid and give it the value uid.\uf020 if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name. Drainage String Element Page 719 12d Model Macro Manual"
+    "description": "For the Element drain and on the pipe number pipe, if the attribute called att_name does not exist then create it as type Uid and give it the value uid. if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name. Drainage String Element Page 719 12d Model Macro Manual"
   },
   {
     "name": "Set_drainage_pipe_attribute",
@@ -30776,7 +30748,7 @@
         "type": "Attributes"
       }
     ],
-    "description": "For the Element drain and on the pipe number pipe,\uf020 if the attribute called att_name does not exist then create it as type Attributes and give it the value att.\uf020 if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element drain and on the pipe number pipe, if the attribute called att_name does not exist then create it as type Attributes and give it the value att. if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_drainage_pipe_attribute",
@@ -30916,7 +30888,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the Element drain and on the pipe number pipe,\uf020 if the attribute called att_name does not exist then create it as type Real and give it the value real.\uf020 if the attribute called att_name does exist and it is type Real, then set its value to real. Page 726 Drainage String Element Chapter 5 12dPL Library Calls If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_drainage_pipe_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the Element drain and on the pipe number pipe, if the attribute called att_name does not exist then create it as type Real and give it the value real. if the attribute called att_name does exist and it is type Real, then set its value to real. Page 726 Drainage String Element Chapter 5 12dPL Library Calls If the attribute exists and is not of type Real then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_drainage_pipe_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_drainage_pipe_attribute",
@@ -30940,7 +30912,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the Element drain and on the pipe number pipe,\uf020 if the attribute with number att_no does not exist then create it as type Integer and give it the value int.\uf020 if the attribute with number att_no does exist and it is type Integer, then set its value to int. If the attribute exists and is not of type Integer then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_drainage_pipe_attribute_type call can be used to get the type of the attribute number att_no."
+    "description": "For the Element drain and on the pipe number pipe, if the attribute with number att_no does not exist then create it as type Integer and give it the value int. if the attribute with number att_no does exist and it is type Integer, then set its value to int. If the attribute exists and is not of type Integer then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_drainage_pipe_attribute_type call can be used to get the type of the attribute number att_no."
   },
   {
     "name": "Set_drainage_pipe_attribute",
@@ -30964,7 +30936,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the Element drain and on the pipe number pipe,\uf020 if the attribute with number att_no does not exist then create it as type Real and give it the value real.\uf020 if the attribute with number att_no does exist and it is type Real, then set its value to real. If the attribute exists and is not of type Real then a non-zero return value is returned. Drainage String Element Page 727 12d Model Macro Manual A function return value of zero indicates the attribute value is successfully set. Note - the Get_drainage_pipe_attribute_type call can be used to get the type of the attribute number att_no."
+    "description": "For the Element drain and on the pipe number pipe, if the attribute with number att_no does not exist then create it as type Real and give it the value real. if the attribute with number att_no does exist and it is type Real, then set its value to real. If the attribute exists and is not of type Real then a non-zero return value is returned. Drainage String Element Page 727 12d Model Macro Manual A function return value of zero indicates the attribute value is successfully set. Note - the Get_drainage_pipe_attribute_type call can be used to get the type of the attribute number att_no."
   },
   {
     "name": "Get_drainage_hcs",
@@ -31028,7 +31000,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the adopted level for the h\u2019th house connection to level. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the adopted level for the h’th house connection to level. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_adopted_level",
@@ -31048,7 +31020,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the adopted level for the h\u2019th house connection of the string Element drain. The adopted level of the house connection is returned in Real level. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the adopted level for the h’th house connection of the string Element drain. The adopted level of the house connection is returned in Real level. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_bush",
@@ -31068,7 +31040,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the drainage string drain, set the bush type for the h\u2019th house connection to bush. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the bush type for the h’th house connection to bush. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_bush",
@@ -31088,7 +31060,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get the bush type for the h\u2019th house connection of the string Element drain. The bush type of the house connection is returned in Text bush. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the bush type for the h’th house connection of the string Element drain. The bush type of the house connection is returned in Text bush. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_colour",
@@ -31108,7 +31080,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the drainage string drain, set the colour number for the h\u2019th house connection to colour. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the colour number for the h’th house connection to colour. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_colour",
@@ -31128,7 +31100,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the colour for the h\u2019th house connection of the string Element drain. The colour of the house connection is returned in Integer colour. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the colour for the h’th house connection of the string Element drain. The colour of the house connection is returned in Integer colour. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_depth",
@@ -31148,7 +31120,7 @@
         "type": "Real"
       }
     ],
-    "description": "Page 730 Drainage String Element Chapter 5 12dPL Library Calls For the drainage string drain, set the depth for the h\u2019th house connection to depth. A function return value of zero indicates the data was successfully set."
+    "description": "Page 730 Drainage String Element Chapter 5 12dPL Library Calls For the drainage string drain, set the depth for the h’th house connection to depth. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_depth",
@@ -31168,7 +31140,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the depth for the h\u2019th house connection of the string Element drain. The depth of the house connection is returned in Real depth. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the depth for the h’th house connection of the string Element drain. The depth of the house connection is returned in Real depth. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_diameter",
@@ -31188,7 +31160,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the diameter for the h\u2019th house connection to diameter. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the diameter for the h’th house connection to diameter. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_diameter",
@@ -31208,7 +31180,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the diameter for the h\u2019th house connection of the string Element drain. The diameter of the house connection is returned in Real diameter. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the diameter for the h’th house connection of the string Element drain. The diameter of the house connection is returned in Real diameter. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_grade",
@@ -31228,7 +31200,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the grade for the h\u2019th house connection to grade. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the grade for the h’th house connection to grade. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_drainage_hc_hcb",
@@ -31248,7 +31220,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the drainage string drain, set the hcb for the h\u2019th house connection to hcb. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the hcb for the h’th house connection to hcb. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_hcb",
@@ -31268,7 +31240,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the hcb for the h\u2019th house connection of the string Element drain. The hcb of the house connection is returned in Integer hcb. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the hcb for the h’th house connection of the string Element drain. The hcb of the house connection is returned in Integer hcb. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_length",
@@ -31288,7 +31260,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the length for the h\u2019th house connection to length. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the length for the h’th house connection to length. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_length",
@@ -31308,7 +31280,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the length for the h\u2019th house connection of the string Element drain. The length of the house connection is returned in Real length. Page 732 Drainage String Element Chapter 5 12dPL Library Calls A function return value of zero indicates the data was successfully returned."
+    "description": "Get the length for the h’th house connection of the string Element drain. The length of the house connection is returned in Real length. Page 732 Drainage String Element Chapter 5 12dPL Library Calls A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_level",
@@ -31328,7 +31300,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the level for the h\u2019th house connection to level. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the level for the h’th house connection to level. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_level",
@@ -31348,7 +31320,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the level for the h\u2019th house connection of the string Element drain. The level of the house connection is returned in Real level. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the level for the h’th house connection of the string Element drain. The level of the house connection is returned in Real level. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_material",
@@ -31368,7 +31340,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the drainage string drain, set the material for the h\u2019th house connection to material. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the material for the h’th house connection to material. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_material",
@@ -31388,7 +31360,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get the material for the h\u2019th house connection of the string Element drain. The material of the house connection is returned in Text material. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the material for the h’th house connection of the string Element drain. The material of the house connection is returned in Text material. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Get_drainage_hc_name",
@@ -31408,7 +31380,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get the name for the h\u2019th house connection of the string Element drain. The name of the house connection is returned in Text name. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the name for the h’th house connection of the string Element drain. The name of the house connection is returned in Text name. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_side",
@@ -31428,7 +31400,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the drainage string drain, set the side for the h\u2019th house connection by the value of side. when side = -1, the house connection is on the left side of the string. when side = 1, the house connection is on the right side of the string. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the side for the h’th house connection by the value of side. when side = -1, the house connection is on the left side of the string. when side = 1, the house connection is on the right side of the string. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_side",
@@ -31448,7 +31420,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the side for the h\u2019th house connection of the string Element drain. The side of the house connection is returned in Integer side. If side = -1, the house connection is on the left side of the string. If side = 1, the house connection is on the right side of the string. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the side for the h’th house connection of the string Element drain. The side of the house connection is returned in Integer side. If side = -1, the house connection is on the left side of the string. If side = 1, the house connection is on the right side of the string. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_drainage_hc_type",
@@ -31468,7 +31440,7 @@
         "type": "Text"
       }
     ],
-    "description": "Page 734 Drainage String Element Chapter 5 12dPL Library Calls For the drainage string drain, set the hc type for the h\u2019th house connection to type. A function return value of zero indicates the data was successfully set."
+    "description": "Page 734 Drainage String Element Chapter 5 12dPL Library Calls For the drainage string drain, set the hc type for the h’th house connection to type. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_drainage_hc_type",
@@ -31488,7 +31460,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get the type for the h\u2019th house connection of the string Element drain. The type of the house connection is returned in Text type. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the type for the h’th house connection of the string Element drain. The type of the house connection is returned in Text type. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Get_drainage_hc_chainage",
@@ -31508,7 +31480,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the chainage for the h\u2019th house connection of the string Element drain. The chainage of the house connection is returned in Real chainage. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the chainage for the h’th house connection of the string Element drain. The chainage of the house connection is returned in Real chainage. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Get_drainage_hc_ip",
@@ -31528,7 +31500,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the intersect point for the h\u2019th house connection of the string Element drain. The intersection point of the house connection is returned in Integer ip. ip is zero based (i.e. the first ip = 0) A function return value of zero indicates the data was successfully returned."
+    "description": "Get the intersect point for the h’th house connection of the string Element drain. The intersection point of the house connection is returned in Integer ip. ip is zero based (i.e. the first ip = 0) A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Get_drainage_pc_xyz",
@@ -31756,7 +31728,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the drainage string drain, set the name for the pc\u2019th property control to Text name. Page 738 Drainage String Element Chapter 5 12dPL Library Calls A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the name for the pc’th property control to Text name. Page 738 Drainage String Element Chapter 5 12dPL Library Calls A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_drainage_pc_colour",
@@ -31776,7 +31748,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the drainage string drain, set the colour for the pc\u2019th property control to Integer colour. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the colour for the pc’th property control to Integer colour. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_drainage_pc_grade",
@@ -31796,7 +31768,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the grade for the pc\u2019th property control to Real grade. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the grade for the pc’th property control to Real grade. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_drainage_pc_cover",
@@ -31816,7 +31788,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the cover for the pc\u2019th property control to Real cover. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the cover for the pc’th property control to Real cover. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_drainage_pc_start_level",
@@ -31836,7 +31808,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the start level for the pc\u2019th property control to Real start_level. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the start level for the pc’th property control to Real start_level. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_drainage_pc_diameter",
@@ -31856,7 +31828,7 @@
         "type": "Real"
       }
     ],
-    "description": "Drainage String Element Page 739 12d Model Macro Manual For the drainage string drain, set the diameter for the pc\u2019th property control to Real diameter. A function return value of zero indicates the data was successfully set."
+    "description": "Drainage String Element Page 739 12d Model Macro Manual For the drainage string drain, set the diameter for the pc’th property control to Real diameter. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_drainage_pc_boundary",
@@ -31876,7 +31848,7 @@
         "type": "Real"
       }
     ],
-    "description": "For the drainage string drain, set the boundary for the pc\u2019th property control to Real boundary. A function return value of zero indicates the data was successfully set."
+    "description": "For the drainage string drain, set the boundary for the pc’th property control to Real boundary. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Create_feature",
@@ -33143,7 +33115,7 @@
       },
       {
         "name": "&num_pts",
-        "type": "Integer\uf020"
+        "type": "Integer"
       }
     ],
     "description": "Get the (x,y,z) data for the first max_pts vertices of the face Element elt. Page 758 Face String Element Chapter 5 12dPL Library Calls The (x,y,z) values at each string vertex are returned in the Real arrays x[], y[] and z[]. The maximum number of vertices that can be returned is given by max_pts (usually the size of the arrays). The vertex data returned starts at the first vertex and goes up to the minimum of max_pts and the number of vertices in the string. The actual number of vertices returned is returned by Integer num_pts num_pts <= max_pts If the Element elt is not of type face, then num_pts is returned as zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned."
@@ -33175,7 +33147,7 @@
       },
       {
         "name": "&num_pts",
-        "type": "Integer\uf020"
+        "type": "Integer"
       },
       {
         "name": "start_pt",
@@ -33186,7 +33158,7 @@
   },
   {
     "name": "Set_face_data",
-    "id": 80,
+    "id": 10080,
     "returnType": "Integer",
     "parameters": [
       {
@@ -33214,7 +33186,7 @@
   },
   {
     "name": "Set_face_data",
-    "id": 81,
+    "id": 10081,
     "returnType": "Integer",
     "parameters": [
       {
@@ -33235,6 +33207,10 @@
       },
       {
         "name": "num_pts",
+        "type": "Integer"
+      },
+      {
+        "name": "start_point",
         "type": "Integer"
       }
     ],
@@ -33646,6 +33622,10 @@
         "type": "Real"
       },
       {
+        "name": "model",
+        "type": "Model"
+      },
+      {
         "name": "&out",
         "type": "Element"
       }
@@ -33755,11 +33735,11 @@
       },
       {
         "name": "sx",
-        "type": "Real"
+        "type": "Segment"
       },
       {
         "name": "base_segment",
-        "type": "Segment"
+        "type": "Real"
       },
       {
         "name": "dy",
@@ -36940,6 +36920,10 @@
       {
         "name": "colour",
         "type": "Integer"
+      },
+      {
+        "name": "name",
+        "type": "Text"
       }
     ],
     "description": "Set the colour and name of the item with given index info_index in the face information list of a trimesh e. The function returns 9 if the trimesh has no face information. The function returns 3 if the given index info_index is out of bound. A return value of zero indicates the function call was successful."
@@ -37984,6 +37968,10 @@
       {
         "name": "&trimesh_out",
         "type": "Element"
+      },
+      {
+        "name": "return_message",
+        "type": "Text"
       }
     ],
     "description": "Find the boolean difference between trimesh1 and trimesh2 and assign the result to (trimesh) Element trimesh_out. The name output_trimesh_name and the colour output_trimesh_colour will be used for the result. The result trimesh will also keep the vertices, edges, faces information of the original trimeshes if the respective values of keep_vertex_info, keep_edge_info, keep_face_info are non zero. The Text error would be set to the corresponding error message if the function failed. A return value of zero indicates the function call was successful."
@@ -38051,27 +38039,27 @@
       },
       {
         "name": "&surrounding_area",
-        "type": "Real"
+        "type": "Integer"
       },
       {
         "name": "&has_surface_area",
-        "type": "Integer"
+        "type": "Real"
       },
       {
         "name": "&surface_area",
-        "type": "Real"
+        "type": "Integer"
       },
       {
         "name": "&has_top_plan_area",
-        "type": "Integer"
-      },
-      {
-        "name": "&top_plan_area",
         "type": "Real"
       },
       {
-        "name": "&&top_area",
+        "name": "&top_plan_area",
         "type": "Integer"
+      },
+      {
+        "name": "&&top_area",
+        "type": "Real"
       },
       {
         "name": "&has_bottom_area",
@@ -38215,27 +38203,27 @@
       },
       {
         "name": "&surrounding_area",
-        "type": "Real"
+        "type": "Integer"
       },
       {
         "name": "&has_surface_area",
-        "type": "Integer"
+        "type": "Real"
       },
       {
         "name": "&surface_area",
-        "type": "Real"
+        "type": "Integer"
       },
       {
         "name": "&has_top_plan_area",
-        "type": "Integer"
-      },
-      {
-        "name": "&top_plan_area",
         "type": "Real"
       },
       {
-        "name": "&&top_area",
+        "name": "&top_plan_area",
         "type": "Integer"
+      },
+      {
+        "name": "&&top_area",
+        "type": "Real"
       },
       {
         "name": "&has_bottom_area",
@@ -39646,7 +39634,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the 2d Element elt, set the (x,y) data for num_pts points starting at point number start_pt. This function allows the user to modify a large number of points of the string in one call starting at point number start_pt rather than point one. The maximum number of points that can be set is given by the difference between the number of points in the string and the value of start_pt. Page 844 Strings Replaced by Super Strings Chapter 5 12dPL Library Calls The (x,y) values for the string points are given in the Real arrays x[] and y[]. The number of the first string point to be modified is start_pt. The total number of points to be set is given by Integer num_pts If the Element elt is not of type 2d, then nothing is modified and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully set. Notes (a) A start_pt of one gives the same result as the previous function. (b) This function can not create new 2d Elements but only modify existing 2d Elements.\uf020"
+    "description": "For the 2d Element elt, set the (x,y) data for num_pts points starting at point number start_pt. This function allows the user to modify a large number of points of the string in one call starting at point number start_pt rather than point one. The maximum number of points that can be set is given by the difference between the number of points in the string and the value of start_pt. Page 844 Strings Replaced by Super Strings Chapter 5 12dPL Library Calls The (x,y) values for the string points are given in the Real arrays x[] and y[]. The number of the first string point to be modified is start_pt. The total number of points to be set is given by Integer num_pts If the Element elt is not of type 2d, then nothing is modified and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully set. Notes (a) A start_pt of one gives the same result as the previous function. (b) This function can not create new 2d Elements but only modify existing 2d Elements."
   },
   {
     "name": "Set_2d_data",
@@ -39754,7 +39742,7 @@
   },
   {
     "name": "Get_3d_data",
-    "id": 80,
+    "id": 78,
     "returnType": "Integer",
     "parameters": [
       {
@@ -39786,7 +39774,35 @@
   },
   {
     "name": "Set_3d_data",
-    "id": 83,
+    "id": 80,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "element",
+        "type": "Element"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      },
+      {
+        "name": "num_pts",
+        "type": "Integer"
+      }
+    ],
+    "description": "12dPL function Set_3d_data"
+  },
+  {
+    "name": "Set_3d_data",
+    "id": 81,
     "returnType": "Integer",
     "parameters": [
       {
@@ -40750,7 +40766,7 @@
   },
   {
     "name": "Get_pipe_data",
-    "id": 80,
+    "id": 78,
     "returnType": "Integer",
     "parameters": [
       {
@@ -40782,7 +40798,7 @@
   },
   {
     "name": "Get_pipe_data",
-    "id": 83,
+    "id": 79,
     "returnType": "Integer",
     "parameters": [
       {
@@ -41761,7 +41777,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Modify the chainage-height co-ordinates (ch,ht) and the curve length value, for the i\u2019th vip point of the Alignment string elt. If mode = 0 or 1, the curve is set to be a parabolic vertical curve If mode = 2, the curve is set to be a circular vertical curve A curve length of zero indicates no curve is present. A function return value of zero indicates the vip data was successfully returned."
+    "description": "Modify the chainage-height co-ordinates (ch,ht) and the curve length value, for the i’th vip point of the Alignment string elt. If mode = 0 or 1, the curve is set to be a parabolic vertical curve If mode = 2, the curve is set to be a circular vertical curve A curve length of zero indicates no curve is present. A function return value of zero indicates the vip data was successfully returned."
   },
   {
     "name": "Insert_vip",
@@ -41785,7 +41801,7 @@
         "type": "Real"
       }
     ],
-    "description": "Insert a new vip with chainage-height co-ordinates (ch,ht) before the existing i\u2019th vip point. The parabolic curve length is set to zero. The inserted vip becomes the ith vip and the position of all subsequent vips increases by one. If i is greater than number of vips, then the new vip is appended to the string. If i is less than one, then the new vip is prepended to the string. A function return value of zero indicates that the vip was successfully inserted."
+    "description": "Insert a new vip with chainage-height co-ordinates (ch,ht) before the existing i’th vip point. The parabolic curve length is set to zero. The inserted vip becomes the ith vip and the position of all subsequent vips increases by one. If i is greater than number of vips, then the new vip is appended to the string. If i is less than one, then the new vip is prepended to the string. A function return value of zero indicates that the vip was successfully inserted."
   },
   {
     "name": "Insert_vip",
@@ -41845,7 +41861,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Insert a new vip with chainage-height co-ordinates (ch,ht) and curve length value before the existing i\u2019th vip point. The inserted vip becomes the ith vip and the position of all subsequent vips increases by one. If i is greater than number of vips, then the new vip is appended to the string. If i is less than one, then the new vip is prepended to the string. If mode = 0 or 1, the curve is set to be a parabolic vertical curve If mode = 2, the curve is set to be a circular vertical curve A curve length of zero indicates no curve is present. A function return value of zero indicates that the vip was successfully inserted."
+    "description": "Insert a new vip with chainage-height co-ordinates (ch,ht) and curve length value before the existing i’th vip point. The inserted vip becomes the ith vip and the position of all subsequent vips increases by one. If i is greater than number of vips, then the new vip is appended to the string. If i is less than one, then the new vip is prepended to the string. If mode = 0 or 1, the curve is set to be a parabolic vertical curve If mode = 2, the curve is set to be a circular vertical curve A curve length of zero indicates no curve is present. A function return value of zero indicates that the vip was successfully inserted."
   },
   {
     "name": "Calc_alignment",
@@ -42786,6 +42802,10 @@
       {
         "name": "encoding",
         "type": "Text"
+      },
+      {
+        "name": "standalone",
+        "type": "Integer"
       }
     ],
     "description": "This call sets the details for the XML declaration. If the document does not already contain an XML declaration, one will be added to the top of the document. Returns 0 if successful."
@@ -42823,6 +42843,10 @@
     "id": 2422,
     "returnType": "Integer",
     "parameters": [
+      {
+        "name": "doc",
+        "type": "XML_Document"
+      },
       {
         "name": "&node",
         "type": "XML_Node"
@@ -43252,7 +43276,7 @@
         "type": "Real"
       }
     ],
-    "description": "Open the file called filename, and write the 12d XML of all the Elements in the Model model to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then write the name of model out to the file before the Elements. If output_model_name = 0 then don\u2019t write out the Model name. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Just for this macro call, there is an extra bit in the bool_flags of value 1048576. When this bit is on, then a valid 12D XML header and the corresponding closing tag will also be added to the output file to form a valid 12D XML file. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
+    "description": "Open the file called filename, and write the 12d XML of all the Elements in the Model model to the file. Any coordinates and Reals are written out to precision decimal places. If output_model_name = 1 then write the name of model out to the file before the Elements. If output_model_name = 0 then don’t write out the Model name. For Integer bool_flags see 5.17.4.2 Write_Panel_Flags. Just for this macro call, there is an extra bit in the bool_flags of value 1048576. When this bit is on, then a valid 12D XML header and the corresponding closing tag will also be added to the output file to form a valid 12D XML file. Null values will be written as Real null_value. A function return value of zero indicates the data was successfully written."
   },
   {
     "name": "XML_to_12da",
@@ -43376,7 +43400,7 @@
         "type": "Map_File"
       }
     ],
-    "description": "Open up a mapping file to read. The file unit is returned as Map_file file. The prefix of models is given as Text prefix. The string type is given as Integer use_ptline, 0 \u2013 point string 1 \u2013 line sting. A function return value of zero indicates the file was opened successfully."
+    "description": "Open up a mapping file to read. The file unit is returned as Map_file file. The prefix of models is given as Text prefix. The string type is given as Integer use_ptline, 0 – point string 1 – line sting. A function return value of zero indicates the file was opened successfully."
   },
   {
     "name": "Map_file_close",
@@ -43480,7 +43504,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get nth key\u2019s data from a mapping file. The file is given in Map_file file. The key is returned in Text key. The string name is returned in Text name. The model name is returned in Text model. The string colour is returned in Integer colour. The string type is returned in Integer ptln. The string style is returned in Text style. A function return value of zero indicates the key was returned successfully."
+    "description": "Get nth key’s data from a mapping file. The file is given in Map_file file. The key is returned in Text key. The string name is returned in Text name. The model name is returned in Text model. The string colour is returned in Integer colour. The string type is returned in Integer ptln. The string style is returned in Text style. A function return value of zero indicates the key was returned successfully."
   },
   {
     "name": "Map_file_find_key",
@@ -43564,7 +43588,7 @@
   },
   {
     "name": "Get_project_setting_integer",
-    "id": 3548,
+    "id": 3547,
     "returnType": "Integer",
     "parameters": [
       {
@@ -43576,7 +43600,7 @@
   },
   {
     "name": "Get_project_setting_text",
-    "id": 3551,
+    "id": 3549,
     "returnType": "Text",
     "parameters": [
       {
@@ -43604,7 +43628,7 @@
   },
   {
     "name": "Set_project_setting_real",
-    "id": 3554,
+    "id": 3553,
     "returnType": "Integer",
     "parameters": [
       {
@@ -43620,7 +43644,7 @@
   },
   {
     "name": "Set_project_setting_colour",
-    "id": 3556,
+    "id": 3555,
     "returnType": "Integer",
     "parameters": [
       {
@@ -43649,7 +43673,7 @@
   {
     "name": "Set_message_text",
     "id": 426,
-    "returnType": "void",
+    "returnType": "Integer",
     "parameters": [
       {
         "name": "msg",
@@ -43840,7 +43864,7 @@
         "type": "Text"
       }
     ],
-    "description": "Print the message msg to the prompt message area and then read back a Text from the user reply area of the Macro Console. If LB is clicked on the tin icon at the right hand end of the user reply area, a list of all existing tins is placed in a pop-up. If a tin is selected from the pop-up (using LB), the Tin name is placed in the user reply area. The value of mode determines whether Super Tins are listed in the pop-up. Mode Description 0 Don\u2019t list SuperTin. 1 List SuperTin. The reply, either typed or selected from the Tin pop-up, must be terminated by pressing <Enter> for the macro to continue. The reply is returned in Text ret. A function return value of zero indicates the Text ret is returned successfully."
+    "description": "Print the message msg to the prompt message area and then read back a Text from the user reply area of the Macro Console. If LB is clicked on the tin icon at the right hand end of the user reply area, a list of all existing tins is placed in a pop-up. If a tin is selected from the pop-up (using LB), the Tin name is placed in the user reply area. The value of mode determines whether Super Tins are listed in the pop-up. Mode Description 0 Don’t list SuperTin. 1 List SuperTin. The reply, either typed or selected from the Tin pop-up, must be terminated by pressing <Enter> for the macro to continue. The reply is returned in Text ret. A function return value of zero indicates the Text ret is returned successfully."
   },
   {
     "name": "View_prompt",
@@ -44411,7 +44435,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set a border of the Vertical_Group group with Text text.on the top left side of the border. If text is Panels and Widgets Page 947 12d Model Macro Manual blank, the border is removed. A function return value of zero indicates the border was successfully set. ThetinsareaVertical_Groupof 4 Widgetswithnoborder ThesameVertical_Groupof4 Widgets withborderandtext\"Tins\" Note that for the left and right gaps that the width of the panel doesn\u2019t change but the gap from the sides of the panel to the box is increased"
+    "description": "Set a border of the Vertical_Group group with Text text.on the top left side of the border. If text is Panels and Widgets Page 947 12d Model Macro Manual blank, the border is removed. A function return value of zero indicates the border was successfully set. ThetinsareaVertical_Groupof 4 Widgetswithnoborder ThesameVertical_Groupof4 Widgets withborderandtext\"Tins\" Note that for the left and right gaps that the width of the panel doesn’t change but the gap from the sides of the panel to the box is increased"
   },
   {
     "name": "Set_border",
@@ -44431,7 +44455,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Set a gap around the border of the Vertical_Group group. bx sets the left and right side gap around the border. by sets the top and bottom side gap around of the border. The units of bx and by are screen units (pixels). A function return value of zero indicates the border gap was successfully set. Page 948 Panels and Widgets Chapter Vertical_Group of 4 Widgets with default border gaps andtext \"Tins\" Vertical_Group of 4 Widgets with border gaps bx =10 and by = 20 and text \"Tins\" Note that for the left and right gaps that the width of the panel doesn\u2019t change but the gap from the sides of the panel to the box is increased"
+    "description": "Set a gap around the border of the Vertical_Group group. bx sets the left and right side gap around the border. by sets the top and bottom side gap around of the border. The units of bx and by are screen units (pixels). A function return value of zero indicates the border gap was successfully set. Page 948 Panels and Widgets Chapter Vertical_Group of 4 Widgets with default border gaps andtext \"Tins\" Vertical_Group of 4 Widgets with border gaps bx =10 and by = 20 and text \"Tins\" Note that for the left and right gaps that the width of the panel doesn’t change but the gap from the sides of the panel to the box is increased"
   },
   {
     "name": "Set_gap",
@@ -44595,7 +44619,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Set whether the browse button is available for Widget widget. If mode = 1 use the browse button if mode = 0 don\u2019t use the browse button. The default value for a Widget is mode = 1. If the browse button is not used, the space where the button would be, is removed. Note: This call must be made before the Panel that contains the widget is shown. A function return value of zero indicates the value was valid. BrowsebuttonofaWidget Use_browse_button mode = 1 Use_browse_button mode = 0"
+    "description": "Set whether the browse button is available for Widget widget. If mode = 1 use the browse button if mode = 0 don’t use the browse button. The default value for a Widget is mode = 1. If the browse button is not used, the space where the button would be, is removed. Note: This call must be made before the Panel that contains the widget is shown. A function return value of zero indicates the value was valid. BrowsebuttonofaWidget Use_browse_button mode = 1 Use_browse_button mode = 0"
   },
   {
     "name": "Show_browse_button",
@@ -44611,7 +44635,7 @@
         "type": "Integer"
       }
     ],
-    "description": "This calls you to show or hide the browse button for the Widget widget. If mode = 1 show the browse button if mode = 0 don\u2019t show the browse button. The default value for a Widget is mode = 1. This call can be made after the Widget has been added to a panel and allows the Browse button of the Widget to be turned on and off under the programmers control. Note if Use_browse_button was called with a mode of 0 then this call is ineffective. See Use_browse_button(Widget widget,Integer mode) A function return value of zero indicates the mode was successfully set. BrowseButtonof theTin_BoxWidget Show_browse_button mode = 1 Show_browse_button mode = 0"
+    "description": "This calls you to show or hide the browse button for the Widget widget. If mode = 1 show the browse button if mode = 0 don’t show the browse button. The default value for a Widget is mode = 1. This call can be made after the Widget has been added to a panel and allows the Browse button of the Widget to be turned on and off under the programmers control. Note if Use_browse_button was called with a mode of 0 then this call is ineffective. See Use_browse_button(Widget widget,Integer mode) A function return value of zero indicates the mode was successfully set. BrowseButtonof theTin_BoxWidget Show_browse_button mode = 1 Show_browse_button mode = 0"
   },
   {
     "name": "Set_enable",
@@ -44835,7 +44859,7 @@
         "type": "Widget"
       }
     ],
-    "description": "Show the Widget widget at the cursor\u2019s current position. Note: The call Show_widget(Widget widget,Integer x,Integer y) allows you to give the screen coordinates to position the Widget. See Show_widget(Widget widget,Integer x,Integer y). A function return value of zero indicates the widget was shown successfully."
+    "description": "Show the Widget widget at the cursor’s current position. Note: The call Show_widget(Widget widget,Integer x,Integer y) allows you to give the screen coordinates to position the Widget. See Show_widget(Widget widget,Integer x,Integer y). A function return value of zero indicates the widget was shown successfully."
   },
   {
     "name": "Show_widget",
@@ -44867,7 +44891,7 @@
         "type": "Widget"
       }
     ],
-    "description": "Hide the Widget widget. That is, don\u2019t display the Widget on the screen. Note the Widget still exists but it is not visible on the screen. The Widget will appear again by calling Show_widget. See Show_widget(Widget widget). A function return value of zero indicates the widget was hidden successfully."
+    "description": "Hide the Widget widget. That is, don’t display the Widget on the screen. Note the Widget still exists but it is not visible on the screen. The Widget will appear again by calling Show_widget. See Show_widget(Widget widget). A function return value of zero indicates the widget was hidden successfully."
   },
   {
     "name": "Set_size",
@@ -44983,7 +45007,7 @@
   },
   {
     "name": "Get_id",
-    "id": 1097,
+    "id": 879,
     "returnType": "Integer",
     "parameters": [
       {
@@ -45071,7 +45095,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Widget widget, the help message for widget is set to help_message. This help message will be sent back to 12d Model via Wait_on_widgets(Integer &id,Text &cmd,Text &msg) with command cmd equal to \u201cHelp\u201d, and msg equal to help_message. So a sample bit of code to handle help is Wait_on_widgets(id,cmd,msg); if (cmd == \u201cHelp\u201d) {; Winhelp(panel,\"12d.hlp\",'a',msg); // in the Winhelp file 12d.hlp, // find and display the a table entry msg continue; } A function return value of zero indicates the text was successfully set."
+    "description": "For the Widget widget, the help message for widget is set to help_message. This help message will be sent back to 12d Model via Wait_on_widgets(Integer &id,Text &cmd,Text &msg) with command cmd equal to “Help”, and msg equal to help_message. So a sample bit of code to handle help is Wait_on_widgets(id,cmd,msg); if (cmd == “Help”) {; Winhelp(panel,\"12d.hlp\",'a',msg); // in the Winhelp file 12d.hlp, // find and display the a table entry msg continue; } A function return value of zero indicates the text was successfully set."
   },
   {
     "name": "Get_help",
@@ -45131,7 +45155,7 @@
         "type": "Text"
       }
     ],
-    "description": "Calls the Windows help system to display the key from the named table of the help file help_file. table takes the form \u2018a\u2019, \u2018k\u2019 etc. The Windows help file help_file must exist and be in a location that can be found. A function return value of zero indicates the function was successful."
+    "description": "Calls the Windows help system to display the key from the named table of the help file help_file. table takes the form ‘a’, ‘k’ etc. The Windows help file help_file must exist and be in a location that can be found. A function return value of zero indicates the function was successful."
   },
   {
     "name": "Winhelp",
@@ -45182,7 +45206,7 @@
     "id": 1243,
     "returnType": "Widget_Pages",
     "parameters": [],
-    "description": "A Widget_Pages object allows a number of controls to exist in the same physical location on a dialog. This is very handy if you want a field to change between a Model_Box, View_Box or the like. A bit of sample code might look like, Vertical_Group vgroup1 = Create_vertical_group(0); Model_Box mbox = Create_model_box(\u2026); Append(mbox,vgroup1); Vertical_Group vgroup2 = Create_vertical_group(0); View_Box vbox = Create_view_box(\u2026); Append(vbox,vgroup2); Widget_Pages pages = Create_widget_pages(); Append(vgroup1,pages); Append(vgroup2,pages); Set_page(page,1) // this shows the 1st page - vgroup1 The function return value is the created Widget_pages."
+    "description": "A Widget_Pages object allows a number of controls to exist in the same physical location on a dialog. This is very handy if you want a field to change between a Model_Box, View_Box or the like. A bit of sample code might look like, Vertical_Group vgroup1 = Create_vertical_group(0); Model_Box mbox = Create_model_box(…); Append(mbox,vgroup1); Vertical_Group vgroup2 = Create_vertical_group(0); View_Box vbox = Create_view_box(…); Append(vbox,vgroup2); Widget_Pages pages = Create_widget_pages(); Append(vgroup1,pages); Append(vgroup2,pages); Set_page(page,1) // this shows the 1st page - vgroup1 The function return value is the created Widget_pages."
   },
   {
     "name": "Append",
@@ -45214,7 +45238,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Show (display on the screen) the n\u2019th page of the Widget_Pages pages. Note the \"n\u2019th page\" is the n\u2019th widget appended to the Widget_Pages pages. All the controls associated with the n\u2019th page_no are shown. A function return value of zero indicates the page was successfully set. Panels and Widgets Page 965 12d Model Macro Manual"
+    "description": "Show (display on the screen) the n’th page of the Widget_Pages pages. Note the \"n’th page\" is the n’th widget appended to the Widget_Pages pages. All the controls associated with the n’th page_no are shown. A function return value of zero indicates the page was successfully set. Panels and Widgets Page 965 12d Model Macro Manual"
   },
   {
     "name": "Set_page",
@@ -45250,7 +45274,7 @@
         "type": "Integer"
       }
     ],
-    "description": "For the Widget_Pages pages, get the page number of the page containing the Widget widget. Note the \"n\u2019th page\" of a Widget_Pages is the n\u2019th widget appended to the Widget_Pages. The page n umber is returned as page_no. A function return value of zero indicates the page number was successfully returned."
+    "description": "For the Widget_Pages pages, get the page number of the page containing the Widget widget. Note the \"n’th page\" of a Widget_Pages is the n’th widget appended to the Widget_Pages. The page n umber is returned as page_no. A function return value of zero indicates the page number was successfully returned."
   },
   {
     "name": "Set_dynamic_sizing",
@@ -45710,7 +45734,7 @@
   },
   {
     "name": "Set_data",
-    "id": 997,
+    "id": 977,
     "returnType": "Integer",
     "parameters": [
       {
@@ -45726,7 +45750,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the values available in the choice list. There are nc items in the choices list for the Choice_Box box. For example Text choices[3]; choices[1] = \"top\"; choices[2] = \"middle\"; choices[3] = \"bottom\"; Choice_Box choice_box = Create_choice_box(\"Pick from list\",message); Set_data(choice_box,3,choices); Note: To be valid, any data typed into the Choice_Box information area must be from the choices list. A function return value of zero indicates the nc\u2019th data in the choices list was successfully set."
+    "description": "Set the values available in the choice list. There are nc items in the choices list for the Choice_Box box. For example Text choices[3]; choices[1] = \"top\"; choices[2] = \"middle\"; choices[3] = \"bottom\"; Choice_Box choice_box = Create_choice_box(\"Pick from list\",message); Set_data(choice_box,3,choices); Note: To be valid, any data typed into the Choice_Box information area must be from the choices list. A function return value of zero indicates the nc’th data in the choices list was successfully set."
   },
   {
     "name": "Set_data",
@@ -46458,7 +46482,7 @@
         "type": "Text"
       }
     ],
-    "description": "In the Draw_Box box, draw the text txt at the position (x,y) where the coordinates (x,y) are in the Draw_Box\u2019s coordinate system. The text has size size (in pixels), and the rotation angle of angle radians. If Draw_text is called before a Start_batch_draw (box) call is made, then the Draw_text fails and a non-zero function return value is returned. A function return value of zero indicates the text was successfully drawn. Page 1002 Panels and Widgets Chapter"
+    "description": "In the Draw_Box box, draw the text txt at the position (x,y) where the coordinates (x,y) are in the Draw_Box’s coordinate system. The text has size size (in pixels), and the rotation angle of angle radians. If Draw_text is called before a Start_batch_draw (box) call is made, then the Draw_text fails and a non-zero function return value is returned. A function return value of zero indicates the text was successfully drawn. Page 1002 Panels and Widgets Chapter"
   },
   {
     "name": "Create_file_box",
@@ -46482,7 +46506,7 @@
         "type": "Text"
       }
     ],
-    "description": "Create an input Widget of type File_Box for inputting and validating files. The File_Box is created with the title title_text (see 5.61.10.12 File_Box). The Message_Box message is normally the message box for the panel and is used to display File_Box validation messages. If <enter> is typed into the File_Box, automatic validation is performed by the File_Box according to mode. What the validation is, what messages are written to Message_Box, and what actions automatically occur, depend on the value of mode. For example, CHECK_FILE_NEW 20 // if the file doesn\u2019t exists, the message says \"will be created\" // if it exist, the messages says \"ERROR\" The values for mode and their actions are listed in Appendix A (see File Mode). If LB is clicked on the icon at the right hand end of the File_Box, a list of the files in the current area which match the wild card text wild (for example, *.dat) Is placed in a pop-up. If a file is selected from the pop-up (using LB), the file name is placed in the information area of the File_Box and validation performed according to mode. The function return value is the created File_Box. Special Note: #include \"set_ups.h\" must be in the macro code to define CHECK_FILE_NEW etc."
+    "description": "Create an input Widget of type File_Box for inputting and validating files. The File_Box is created with the title title_text (see 5.61.10.12 File_Box). The Message_Box message is normally the message box for the panel and is used to display File_Box validation messages. If <enter> is typed into the File_Box, automatic validation is performed by the File_Box according to mode. What the validation is, what messages are written to Message_Box, and what actions automatically occur, depend on the value of mode. For example, CHECK_FILE_NEW 20 // if the file doesn’t exists, the message says \"will be created\" // if it exist, the messages says \"ERROR\" The values for mode and their actions are listed in Appendix A (see File Mode). If LB is clicked on the icon at the right hand end of the File_Box, a list of the files in the current area which match the wild card text wild (for example, *.dat) Is placed in a pop-up. If a file is selected from the pop-up (using LB), the file name is placed in the information area of the File_Box and validation performed according to mode. The function return value is the created File_Box. Special Note: #include \"set_ups.h\" must be in the macro code to define CHECK_FILE_NEW etc."
   },
   {
     "name": "Create_file_box",
@@ -47714,7 +47738,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Create an input Widget of type Model_Box for inputting and validating Models. The Model_Box is created with the title title_text (see 5.61.10.21 Model_Box). The Message_Box message is normally the message box for the panel and is used to display Model_Box validation messages. If <enter> is typed into the Model_Box automatic validation is performed by the Model_Box according to mode. What the validation is, what messages are written to Message_Box, and what actions automatically occur, depend on the value of mode. For example, CHECK_MODEL_MUST_EXIST 7 // if the model exists, the message says \"exists\".\uf020 // if it doesn\u2019t exist, the messages says \"ERROR\" The values for mode and their actions are listed in Appendix A (see Model Mode). If LB is clicked on the icon at the right hand end of the Model_Box, a list of all existing models is placed in a pop-up. If a model is selected from the pop-up (using LB), the model name is placed in the information area of the Model_Box and validation performed according to mode. MB for \"Same As\" also applies. That is, If MB is clicked in the information area and then a string from a model on a view is selected, then the name of the model containing the selected string is written to the information area and validation performed according to mode. The function return value is the created Model_Box. Special Note: #include \"set_ups.h\" must be in the macro code to define CHECK_MODEL_MUST_EXIST etc."
+    "description": "Create an input Widget of type Model_Box for inputting and validating Models. The Model_Box is created with the title title_text (see 5.61.10.21 Model_Box). The Message_Box message is normally the message box for the panel and is used to display Model_Box validation messages. If <enter> is typed into the Model_Box automatic validation is performed by the Model_Box according to mode. What the validation is, what messages are written to Message_Box, and what actions automatically occur, depend on the value of mode. For example, CHECK_MODEL_MUST_EXIST 7 // if the model exists, the message says \"exists\". // if it doesn’t exist, the messages says \"ERROR\" The values for mode and their actions are listed in Appendix A (see Model Mode). If LB is clicked on the icon at the right hand end of the Model_Box, a list of all existing models is placed in a pop-up. If a model is selected from the pop-up (using LB), the model name is placed in the information area of the Model_Box and validation performed according to mode. MB for \"Same As\" also applies. That is, If MB is clicked in the information area and then a string from a model on a view is selected, then the name of the model containing the selected string is written to the information area and validation performed according to mode. The function return value is the created Model_Box. Special Note: #include \"set_ups.h\" must be in the macro code to define CHECK_MODEL_MUST_EXIST etc."
   },
   {
     "name": "Validate",
@@ -48062,7 +48086,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the string selection type type for the New_Select_Box select. For example \u201cAlignment\u201d, \u201c3d\u201d. A function return value of zero indicates the type was successfully set."
+    "description": "Set the string selection type type for the New_Select_Box select. For example “Alignment”, “3d”. A function return value of zero indicates the type was successfully set."
   },
   {
     "name": "Set_select_snap_mode",
@@ -48102,7 +48126,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the snap mode snap_mode and snap control snap_control for the New_Select_Box select. Where snap_mode is: Failed_Snap = -1 No_Snap = 0 Point_Snap = 1 Line_Snap = 2 Grid_Snap = 3 Intersection_Snap = 4 Cursor_Snap = 5 Name_Snap = 6 Tin_Snap = 7 Model_Snap = 8 Height_Snap = 9 Segment_Snap = 11 Text_Snap = 12 Fast_Snap = 13 Fast_Accept = 14 and snap_control is Ignore_Snap = 0 User_Snap = 1 Program_Snap = 2 The snap_text must be string name; tin name, model name respectively, otherwise, leave the snap_text blank (\u201c\u201d). A function return value of zero indicates the snap mode was successfully set."
+    "description": "Set the snap mode snap_mode and snap control snap_control for the New_Select_Box select. Where snap_mode is: Failed_Snap = -1 No_Snap = 0 Point_Snap = 1 Line_Snap = 2 Grid_Snap = 3 Intersection_Snap = 4 Cursor_Snap = 5 Name_Snap = 6 Tin_Snap = 7 Model_Snap = 8 Height_Snap = 9 Segment_Snap = 11 Text_Snap = 12 Fast_Snap = 13 Fast_Accept = 14 and snap_control is Ignore_Snap = 0 User_Snap = 1 Program_Snap = 2 The snap_text must be string name; tin name, model name respectively, otherwise, leave the snap_text blank (“”). A function return value of zero indicates the snap mode was successfully set."
   },
   {
     "name": "Set_select_direction",
@@ -48954,7 +48978,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the string selection type type for the Select_Box select. For example \u201cAlignment\u201d, \u201c3d\u201d. A function return value of zero indicates the type was successfully set."
+    "description": "Set the string selection type type for the Select_Box select. For example “Alignment”, “3d”. A function return value of zero indicates the type was successfully set."
   },
   {
     "name": "Set_select_snap_mode",
@@ -48974,7 +48998,7 @@
   },
   {
     "name": "Set_select_snap_mode",
-    "id": 1045,
+    "id": 1050,
     "returnType": "Integer",
     "parameters": [
       {
@@ -48994,7 +49018,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the snap mode snap_mode and snap control snap_control for the Select_Box select. Where snap_mode is: Failed_Snap = -1 No_Snap = 0 Point_Snap = 1 Line_Snap = 2 Grid_Snap = 3 Intersection_Snap = 4 Cursor_Snap = 5 Name_Snap = 6 Tin_Snap = 7 Model_Snap = 8 Height_Snap = 9 Panels and Widgets Page 1073 12d Model Macro Manual Segment_Snap = 11 Text_Snap = 12 Fast_Snap = 13 Fast_Accept = 14 and snap_control is Ignore_Snap = 0 User_Snap = 1 Program_Snap = 2 The snap_text must be string name; tin name, model name respectively, otherwise, leave the snap_text blank (\u201c\u201d). A function return value of zero indicates the snap mode was successfully set."
+    "description": "Set the snap mode snap_mode and snap control snap_control for the Select_Box select. Where snap_mode is: Failed_Snap = -1 No_Snap = 0 Point_Snap = 1 Line_Snap = 2 Grid_Snap = 3 Intersection_Snap = 4 Cursor_Snap = 5 Name_Snap = 6 Tin_Snap = 7 Model_Snap = 8 Height_Snap = 9 Panels and Widgets Page 1073 12d Model Macro Manual Segment_Snap = 11 Text_Snap = 12 Fast_Snap = 13 Fast_Accept = 14 and snap_control is Ignore_Snap = 0 User_Snap = 1 Program_Snap = 2 The snap_text must be string name; tin name, model name respectively, otherwise, leave the snap_text blank (“”). A function return value of zero indicates the snap mode was successfully set."
   },
   {
     "name": "Set_select_direction",
@@ -49138,7 +49162,7 @@
         "type": "Element"
       }
     ],
-    "description": "Validate the nth Element string in the Select_Boxes select. The function returns the value of: NO_NAME if the n\u2019th box of the New_Select_Box is optional and the box is left empty TRUE (1) if no other return code is needed and string is valid. FALSE (zero) if there is an error. So a function return value of zero indicates that there is an error. Warning this is the opposite of most 12dPL function return values"
+    "description": "Validate the nth Element string in the Select_Boxes select. The function returns the value of: NO_NAME if the n’th box of the New_Select_Box is optional and the box is left empty TRUE (1) if no other return code is needed and string is valid. FALSE (zero) if there is an error. So a function return value of zero indicates that there is an error. Warning this is the opposite of most 12dPL function return values"
   },
   {
     "name": "Validate",
@@ -49162,7 +49186,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Validate the nth Element string in the Select_Boxes select. If silent = 0, and there is an error, a message is written and the cursor goes back to the box. If silent = 1 and there is an error, no message or movement of cursor is done. The function returns the value of: NO_NAME if the n\u2019th box of the New_Select_Box is optional and the box is left empty Panels and Widgets Page 1077 12d Model Macro Manual TRUE (1) if no other return code is needed and string is valid. FALSE (zero) if there is an error. So a function return value of zero indicates that there is an error. Warning this is the opposite of most 12dPL function return values"
+    "description": "Validate the nth Element string in the Select_Boxes select. If silent = 0, and there is an error, a message is written and the cursor goes back to the box. If silent = 1 and there is an error, no message or movement of cursor is done. The function returns the value of: NO_NAME if the n’th box of the New_Select_Box is optional and the box is left empty Panels and Widgets Page 1077 12d Model Macro Manual TRUE (1) if no other return code is needed and string is valid. FALSE (zero) if there is an error. So a function return value of zero indicates that there is an error. Warning this is the opposite of most 12dPL function return values"
   },
   {
     "name": "Set_data",
@@ -49182,7 +49206,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the Element of the n\u2019th box in the Select_Boxes select by giving the model name and string name as a Text model_string in the form \"model_name->string_name\". A function return value of zero indicates the data was successfully set."
+    "description": "Set the Element of the n’th box in the Select_Boxes select by giving the model name and string name as a Text model_string in the form \"model_name->string_name\". A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Set_data",
@@ -49202,7 +49226,7 @@
         "type": "Element"
       }
     ],
-    "description": "Set the data of type Element for the n\u2019th box in the Select_Boxes select to string. A function return value of zero indicates the data was successfully set."
+    "description": "Set the data of type Element for the n’th box in the Select_Boxes select to string. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_data",
@@ -49222,7 +49246,7 @@
         "type": "Text"
       }
     ],
-    "description": "Get the model and string name of the Element in the n\u2019th box of the Select_Boxes select. and return it in the Text model_string, Note: the model and string name is in the form \"model_name->string_name\" so only one Text is required. A function return value of zero indicates the data was successfully returned."
+    "description": "Get the model and string name of the Element in the n’th box of the Select_Boxes select. and return it in the Text model_string, Note: the model and string name is in the form \"model_name->string_name\" so only one Text is required. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Select_start",
@@ -49238,7 +49262,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Starts the string selection for the n\u2019th box of the Select_Boxes select. This is the same as if the button on the n\u2019th box of Select_Boxes had been clicked. Page 1078 Panels and Widgets Chapter A function return value of zero indicates the start was successful."
+    "description": "Starts the string selection for the n’th box of the Select_Boxes select. This is the same as if the button on the n’th box of Select_Boxes had been clicked. Page 1078 Panels and Widgets Chapter A function return value of zero indicates the start was successful."
   },
   {
     "name": "Select_end",
@@ -49254,7 +49278,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Cancels the string selection that is running for the n\u2019th box of the Select_Boxes n\u2019th box of the Select_Boxes select. This is the same as if Cancel had been selected from the Pick Ops menu. A function return value of zero indicates the end was successful."
+    "description": "Cancels the string selection that is running for the n’th box of the Select_Boxes n’th box of the Select_Boxes select. This is the same as if Cancel had been selected from the Pick Ops menu. A function return value of zero indicates the end was successful."
   },
   {
     "name": "Set_select_type",
@@ -49274,7 +49298,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the string selection for the n\u2019th box of the Select_Boxes select to type. For example \u201cAlignment\u201d, \u201c3d\u201d. A function return value of zero indicates the type was successfully set."
+    "description": "Set the string selection for the n’th box of the Select_Boxes select to type. For example “Alignment”, “3d”. A function return value of zero indicates the type was successfully set."
   },
   {
     "name": "Set_select_snap_mode",
@@ -49294,7 +49318,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Set the snap control for n\u2019th box of the Select_Boxes select to control. snap control control value Ignore_Snap 0 User_Snap Program_Snap 2 A function return value of zero indicates the snap control was successfully set."
+    "description": "Set the snap control for n’th box of the Select_Boxes select to control. snap control control value Ignore_Snap 0 User_Snap Program_Snap 2 A function return value of zero indicates the snap control was successfully set."
   },
   {
     "name": "Set_select_snap_mode",
@@ -49322,7 +49346,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the snap mode mode and snap control snap_control for the nth box of the Select_Boxes select. Panels and Widgets Page 1079 12d Model Macro Manual When snap mode is: Name_Snap 6 Tin_Snap 7 Model_Snap 8 the snap_text must be string name; tin name, model name respectively, otherwise, leave the snap_text blank (\u201c\u201d). A function return value of zero indicates the snap mode was successfully set."
+    "description": "Set the snap mode mode and snap control snap_control for the nth box of the Select_Boxes select. Panels and Widgets Page 1079 12d Model Macro Manual When snap mode is: Name_Snap 6 Tin_Snap 7 Model_Snap 8 the snap_text must be string name; tin name, model name respectively, otherwise, leave the snap_text blank (“”). A function return value of zero indicates the snap mode was successfully set."
   },
   {
     "name": "Set_select_direction",
@@ -49342,7 +49366,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Set the selection direction dir of the string selected for the n\u2019th box of the Select_Boxes select. The input dir type must be Integer. Dir Value Pick direction 1 the direction of the string -1 against the direction of the string A function return value of zero indicates the direction was successfully set."
+    "description": "Set the selection direction dir of the string selected for the n’th box of the Select_Boxes select. The input dir type must be Integer. Dir Value Pick direction 1 the direction of the string -1 against the direction of the string A function return value of zero indicates the direction was successfully set."
   },
   {
     "name": "Get_select_direction",
@@ -49362,7 +49386,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the selection direction dir of the string selected for the n\u2019th box of the Select_Boxes select. The returned dir type must be Integer. If select without direction, the returned dir is 1, otherwise, the returned dir is: Dir Value Pick direction 1 the direction of the string -1 against the direction of the string A function return value of zero indicates the direction was successfully returned."
+    "description": "Get the selection direction dir of the string selected for the n’th box of the Select_Boxes select. The returned dir type must be Integer. If select without direction, the returned dir is 1, otherwise, the returned dir is: Dir Value Pick direction 1 the direction of the string -1 against the direction of the string A function return value of zero indicates the direction was successfully returned."
   },
   {
     "name": "Set_select_coordinate",
@@ -49398,7 +49422,7 @@
         "type": "Real"
       }
     ],
-    "description": "Page 1080 Panels and Widgets Chapter Get the coordinate, chainage and height of the snap point of the string selected for the n\u2019th box of the Select_Boxes select. The input value of x, y, z, ch, and ht are of type of Real. A function return value of zero indicates the coordinate was successfully set."
+    "description": "Page 1080 Panels and Widgets Chapter Get the coordinate, chainage and height of the snap point of the string selected for the n’th box of the Select_Boxes select. The input value of x, y, z, ch, and ht are of type of Real. A function return value of zero indicates the coordinate was successfully set."
   },
   {
     "name": "Get_select_coordinate",
@@ -49434,7 +49458,7 @@
         "type": "Real"
       }
     ],
-    "description": "Get the coordinate, chainage and height of the snap point of the string selected for the n\u2019th box of the Select_Boxes select. The return value of x, y, z, ch, and ht are of type of Real. A function return value of zero indicates the coordinate was successfully returned."
+    "description": "Get the coordinate, chainage and height of the snap point of the string selected for the n’th box of the Select_Boxes select. The return value of x, y, z, ch, and ht are of type of Real. A function return value of zero indicates the coordinate was successfully returned."
   },
   {
     "name": "Create_sheet_size_box",
@@ -49594,7 +49618,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Create an input Widget of type Source_Box which is used to define how to select data. See 5.61.10.35 Source_Box. The Source_Box is created with the title \"Data \" followed by title_text. What Data Source Choices are displayed and hence available to select, is controlled by flags. i If flags = 0, then all the choices are displayed. Model Source_Box_Model = 0x001 = 1 View Source_Box_View = 0x002 = 2 String Source_Box_String = 0x004 = 4 Rectangle Source_Box_Rectangle = 0x008 = 8 Trapezoid Source_Box_Trapezoid = 0x010 = 16 Polygon Source_Box_Polygon = 0x020 Lasso Source_Box_Lasso = 0x040 Filter Source_Box_Filter = 0x080 Models Source_Box_Models = 0x100 Favourites Source_Box_Favorites = 0x200 All Source_Box_All = 0xfff Fence inside Source_Box_Fence_Inside = 0x01000 Fence cross Source_Box_Fence_Cross = 0x02000 Fence outside Source_Box_Fence_Outside = 0x04000 Fence string Source_Box_Fence_String = 0x08000 Fence points Source_Box_Fence_Points = 0x10000 Fence all Source_Box_Fence_All = 0xff000 Source_Box_Standard = Source_Box_All | Source_Box_Fence_Inside | \uf020 Source_Box_Fence_Outside | Source_Box_Fence_Cross | Source_Box_Fence_String You can have just some of them by combining the ones you want with |. For example Source_Box_Model | Source_Box_View The Message_Box message is used to display information. The function return value is the created Source_Box."
+    "description": "Create an input Widget of type Source_Box which is used to define how to select data. See 5.61.10.35 Source_Box. The Source_Box is created with the title \"Data \" followed by title_text. What Data Source Choices are displayed and hence available to select, is controlled by flags. i If flags = 0, then all the choices are displayed. Model Source_Box_Model = 0x001 = 1 View Source_Box_View = 0x002 = 2 String Source_Box_String = 0x004 = 4 Rectangle Source_Box_Rectangle = 0x008 = 8 Trapezoid Source_Box_Trapezoid = 0x010 = 16 Polygon Source_Box_Polygon = 0x020 Lasso Source_Box_Lasso = 0x040 Filter Source_Box_Filter = 0x080 Models Source_Box_Models = 0x100 Favourites Source_Box_Favorites = 0x200 All Source_Box_All = 0xfff Fence inside Source_Box_Fence_Inside = 0x01000 Fence cross Source_Box_Fence_Cross = 0x02000 Fence outside Source_Box_Fence_Outside = 0x04000 Fence string Source_Box_Fence_String = 0x08000 Fence points Source_Box_Fence_Points = 0x10000 Fence all Source_Box_Fence_All = 0xff000 Source_Box_Standard = Source_Box_All | Source_Box_Fence_Inside |  Source_Box_Fence_Outside | Source_Box_Fence_Cross | Source_Box_Fence_String You can have just some of them by combining the ones you want with |. For example Source_Box_Model | Source_Box_View The Message_Box message is used to display information. The function return value is the created Source_Box."
   },
   {
     "name": "Create_source_box",
@@ -49666,7 +49690,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Source_Box box, write out the Source_Box selection information to the file named filename. Note: the Read_favourite and Write_favourite calls allow Source_Box selection settings to be saved, and passed around between different Source_Box\u2019s. A function return value of zero indicates the file was successfully written."
+    "description": "For the Source_Box box, write out the Source_Box selection information to the file named filename. Note: the Read_favourite and Write_favourite calls allow Source_Box selection settings to be saved, and passed around between different Source_Box’s. A function return value of zero indicates the file was successfully written."
   },
   {
     "name": "Create_symbol_box",
@@ -50422,7 +50446,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Create an input Widget of type Tin_Box for inputting and validating Tins. The Tin_Box is created with the title title_text (see 5.61.10.45 Tin_Box). The Message_Box message is normally the message box for the panel and is used to display Model_Box validation messages. If <enter> is typed into the Tin_Box or a tin selected from the tin pop-up list, automatic validation is performed by the Tin_Box according to mode. What the validation is, what messages are written to Message_Box, and what actions automatically occur, depend on the value of mode. For example, CHECK_TIN_MUST_EXIST // if the tins exists, the message says \"exists\"\uf020 // if it doesn\u2019t exist, the messages says \"ERROR\" The values for mode and their actions are listed in Appendix A (see Tin Mode). The function return value is the created Tin_Box."
+    "description": "Create an input Widget of type Tin_Box for inputting and validating Tins. The Tin_Box is created with the title title_text (see 5.61.10.45 Tin_Box). The Message_Box message is normally the message box for the panel and is used to display Model_Box validation messages. If <enter> is typed into the Tin_Box or a tin selected from the tin pop-up list, automatic validation is performed by the Tin_Box according to mode. What the validation is, what messages are written to Message_Box, and what actions automatically occur, depend on the value of mode. For example, CHECK_TIN_MUST_EXIST // if the tins exists, the message says \"exists\" // if it doesn’t exist, the messages says \"ERROR\" The values for mode and their actions are listed in Appendix A (see Tin Mode). The function return value is the created Tin_Box."
   },
   {
     "name": "Validate",
@@ -50646,7 +50670,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Create an input Widget of type View_Box for inputting and validating Views. The View_Box is created with the title title_text (see 5.61.10.46 View_Box). The Message_Box message is normally the message box of the panel and is used to display the View_Box validation messages. If an <enter> is typed in the View_Box or a view selected from the view pop-up list, automatic validation is performed by the View_Box according to mode - what the validation is, what messages are written to Message_Box, and what actions automatically occur, depend on the value of mode. For example, CHECK_TIN_MUST_EXIST // if the model exists, the message says \"exists\" and\uf020 // if it doesn\u2019t exist, the messages says \"ERROR\" The value of mode and their actions are listed in Appendix A (see View Mode). The function return value is the created View_Box."
+    "description": "Create an input Widget of type View_Box for inputting and validating Views. The View_Box is created with the title title_text (see 5.61.10.46 View_Box). The Message_Box message is normally the message box of the panel and is used to display the View_Box validation messages. If an <enter> is typed in the View_Box or a view selected from the view pop-up list, automatic validation is performed by the View_Box according to mode - what the validation is, what messages are written to Message_Box, and what actions automatically occur, depend on the value of mode. For example, CHECK_TIN_MUST_EXIST // if the model exists, the message says \"exists\" and // if it doesn’t exist, the messages says \"ERROR\" The value of mode and their actions are listed in Appendix A (see View Mode). The function return value is the created View_Box."
   },
   {
     "name": "Validate",
@@ -51058,7 +51082,7 @@
         "type": "Integer"
       }
     ],
-    "description": "Create a Text Log_Line with the message message and a log level log_level. The text message is displayed in a Log_Box with the log level log_level when the Log_Line is added to the Log_Box. Available log levels are 0 for none, 1 for General, 2 for Warning 3 for Error. Log levels other than 0 will display a small icon to indicate their status. icons for log_level\u2019s WARNING To be visible, the created Log_Line is added to a Log_Box using the call Add_log_line(Log_Box box,Log_Line line) BUT this call can only be made after the Log_Box is displayed in a panel using the Show_panel call. The function return code is the created Log_Line."
+    "description": "Create a Text Log_Line with the message message and a log level log_level. The text message is displayed in a Log_Box with the log level log_level when the Log_Line is added to the Log_Box. Available log levels are 0 for none, 1 for General, 2 for Warning 3 for Error. Log levels other than 0 will display a small icon to indicate their status. icons for log_level’s WARNING To be visible, the created Log_Line is added to a Log_Box using the call Add_log_line(Log_Box box,Log_Line line) BUT this call can only be made after the Log_Box is displayed in a panel using the Show_panel call. The function return code is the created Log_Line."
   },
   {
     "name": "Create_highlight_string_log_line",
@@ -51501,28 +51525,8 @@
     "description": "Get the user action number index (1 2 3 counting of the order that actions being added) of the given Log_Line line, and set the time to action_time. action_time is when the user last performed the action. 0 means not actioned A function return value of zero indicates the get was successful."
   },
   {
-    "name": "Get_log_line_action_id_help",
-    "id": 7972,
-    "returnType": "Integer",
-    "parameters": [
-      {
-        "name": "line",
-        "type": "Log_Line"
-      },
-      {
-        "name": "id",
-        "type": "Integer"
-      },
-      {
-        "name": "&action_help",
-        "type": "Text"
-      }
-    ],
-    "description": "Get the user action number index (1 2 3 counting of the order that actions being added) of the given Log_Line line, and set the help text to action_help. A function return value of zero indicates the get was successful."
-  },
-  {
     "name": "Get_log_line_action_id_mode",
-    "id": 7973,
+    "id": 7969,
     "returnType": "Integer",
     "parameters": [
       {
@@ -51794,7 +51798,7 @@
         "type": "Text"
       }
     ],
-    "description": "Set the type of the string that can be selected to type for Select_Botton select. For example \u201cAlignment\u201d, \u201c3d\u201d. A function return value of zero indicates the type was successfully set."
+    "description": "Set the type of the string that can be selected to type for Select_Botton select. For example “Alignment”, “3d”. A function return value of zero indicates the type was successfully set."
   },
   {
     "name": "Set_select_snap_mode",
@@ -51830,7 +51834,7 @@
   },
   {
     "name": "Set_select_snap_mode",
-    "id": 1047,
+    "id": 1045,
     "returnType": "Integer",
     "parameters": [
       {
@@ -51850,7 +51854,7 @@
         "type": "Text"
       }
     ],
-    "description": "Panels and Widgets Page 1163 12d Model Macro Manual Set the snap mode mode and snap control control for the Select_Button select. When snap mode is: Name_Snap 6 Tin_Snap 7 Model_Snap 8 the snap_text must be string name; tin name, model name accordingly, otherwise, leave the snap_text blank \u201c\u201d. A function return value of zero indicates the type was successfully set. Get_select_coordinate(Select_Button select,Real &x,Real &y,Real &z,Real &ch,Real &ht) Name Integer Get_select_coordinate(Select_Button select,Real &x,Real &y,Real &z,Real &ch,Real &ht) Description Get the coordinate of the selected snap point. The return value of x, y, z, ch and ht must be type of Real. A function return value of zero indicates the coordinate was successfully returned."
+    "description": "Panels and Widgets Page 1163 12d Model Macro Manual Set the snap mode mode and snap control control for the Select_Button select. When snap mode is: Name_Snap 6 Tin_Snap 7 Model_Snap 8 the snap_text must be string name; tin name, model name accordingly, otherwise, leave the snap_text blank “”. A function return value of zero indicates the type was successfully set. Get_select_coordinate(Select_Button select,Real &x,Real &y,Real &z,Real &ch,Real &ht) Name Integer Get_select_coordinate(Select_Button select,Real &x,Real &y,Real &z,Real &ch,Real &ht) Description Get the coordinate of the selected snap point. The return value of x, y, z, ch and ht must be type of Real. A function return value of zero indicates the coordinate was successfully returned."
   },
   {
     "name": "Create_help_button",
@@ -51958,7 +51962,7 @@
         "type": "Integer"
       }
     ],
-    "description": "This call inserts a blank row into the GridCtrl_Box grid. If is_before = 1, a blank row is inserted before row_num, so that the blank row becomes the new row_num\u2019th row. The old rows from row row_num onwards are all pushed down one row. If is_before = 0, a blank row is after row row_num, so that the blank row becomes a new (num_row+1)\u2019th row. The old rows from row (num_row+1) onwards are pushed down one row. t row number row_num of the GridCtrl_Box grid. If you wish it to be inserted before the specified row, set is_before to 1, otherwise the row will be inserted after. Note: a GridCtrl_Box(grid) call should be done after the Insert_row(GridCtrl_Box grid,Integer row_num,Integer is_before) call. See Format_grid(GridCtrl_Box grid). A function return value of a positive number indicates the insertion was successful; and the number should equal the number of rows after the insertion."
+    "description": "This call inserts a blank row into the GridCtrl_Box grid. If is_before = 1, a blank row is inserted before row_num, so that the blank row becomes the new row_num’th row. The old rows from row row_num onwards are all pushed down one row. If is_before = 0, a blank row is after row row_num, so that the blank row becomes a new (num_row+1)’th row. The old rows from row (num_row+1) onwards are pushed down one row. t row number row_num of the GridCtrl_Box grid. If you wish it to be inserted before the specified row, set is_before to 1, otherwise the row will be inserted after. Note: a GridCtrl_Box(grid) call should be done after the Insert_row(GridCtrl_Box grid,Integer row_num,Integer is_before) call. See Format_grid(GridCtrl_Box grid). A function return value of a positive number indicates the insertion was successful; and the number should equal the number of rows after the insertion."
   },
   {
     "name": "Delete_row",
@@ -52362,7 +52366,7 @@
         "type": "Tree_Box"
       }
     ],
-    "description": "Get the root page of the Tree_Box tree_box and return it as the function return value. All Tree_Box\u2019s automatically have a root page."
+    "description": "Get the root page of the Tree_Box tree_box and return it as the function return value. All Tree_Box’s automatically have a root page."
   },
   {
     "name": "Create_tree_page",
@@ -52386,7 +52390,7 @@
         "type": "Integer"
       }
     ],
-    "description": "This call creates a new Tree_Page with the name name, as a child of the Tree_Page parent_page. Note: a lot of tree pages created in one instance of 12D will crash 12D because of the limited GDI count Windows allow for each running application. When the right hand side of the created page exists and there is none or more than one Group (either Horizontal_Group\u2019s and/or Vertical_Group\u2019s), then the right hand side can have an optional border and be given the name of the Tree_Page as a title for the border. If show_border = 1, a border is drawn around the right had side of the created Tree_Page. If show_border = 0, no border is drawn around the right had side of the created Tree_Page. If use_name_for_border = 1, name is used as the title when the border is drawn around the right Page 1180 Panels and Widgets Chapter had side of the created Tree_Page. If use_name_for_border = 0, there is no title when the border is drawn around the right had side of the created Tree_Page. Title for border Border around right hand side of \"Page1\" Right hand side of Tree_Page \"Page 1\" The right hand side comes up when you click on \"Page 1\" in the Tree on the left A parent page must exist before a child page can be created. The parent page may be the root page that is automatically created for a Tree_Box and the Get_root_page call is used to get the root page of a Tree_Box. See Get_root_page(Tree_Box tree_box) A Tree_Page can contain any number of children pages. An example of a section of the code required to create a Tree_Box with its root page, and then one child page of the root page is: Tree_Box tree_box = Create_tree_box(\"Tree\", \"Tree Root\", 200, 200); // get the root page to add a child page called \"Page 1\" to Tree_Page root_page = Get_root_page(tree_box); Tree_Page page_1 = Create_tree_page(root_page, \"Page 1\", 1, 1); Panels and Widgets Page 1181 12d Model Macro Manual The created Tree_Box is returned as the function return value."
+    "description": "This call creates a new Tree_Page with the name name, as a child of the Tree_Page parent_page. Note: a lot of tree pages created in one instance of 12D will crash 12D because of the limited GDI count Windows allow for each running application. When the right hand side of the created page exists and there is none or more than one Group (either Horizontal_Group’s and/or Vertical_Group’s), then the right hand side can have an optional border and be given the name of the Tree_Page as a title for the border. If show_border = 1, a border is drawn around the right had side of the created Tree_Page. If show_border = 0, no border is drawn around the right had side of the created Tree_Page. If use_name_for_border = 1, name is used as the title when the border is drawn around the right Page 1180 Panels and Widgets Chapter had side of the created Tree_Page. If use_name_for_border = 0, there is no title when the border is drawn around the right had side of the created Tree_Page. Title for border Border around right hand side of \"Page1\" Right hand side of Tree_Page \"Page 1\" The right hand side comes up when you click on \"Page 1\" in the Tree on the left A parent page must exist before a child page can be created. The parent page may be the root page that is automatically created for a Tree_Box and the Get_root_page call is used to get the root page of a Tree_Box. See Get_root_page(Tree_Box tree_box) A Tree_Page can contain any number of children pages. An example of a section of the code required to create a Tree_Box with its root page, and then one child page of the root page is: Tree_Box tree_box = Create_tree_box(\"Tree\", \"Tree Root\", 200, 200); // get the root page to add a child page called \"Page 1\" to Tree_Page root_page = Get_root_page(tree_box); Tree_Page page_1 = Create_tree_page(root_page, \"Page 1\", 1, 1); Panels and Widgets Page 1181 12d Model Macro Manual The created Tree_Box is returned as the function return value."
   },
   {
     "name": "Append",
@@ -52434,7 +52438,7 @@
         "type": "Tree_Page"
       }
     ],
-    "description": "For the Tree_Page parent, find the n\u2019th child page of parent and return the page as child_page. A function return value of zero indicates a child page was successfully returned."
+    "description": "For the Tree_Page parent, find the n’th child page of parent and return the page as child_page. A function return value of zero indicates a child page was successfully returned."
   },
   {
     "name": "Has_widget",
@@ -52862,7 +52866,7 @@
   },
   {
     "name": "Drape",
-    "id": 3790,
+    "id": 144,
     "returnType": "Integer",
     "parameters": [
       {
@@ -52871,7 +52875,7 @@
       },
       {
         "name": "model",
-        "type": "Model"
+        "type": "Dynamic_Element"
       },
       {
         "name": "&draped_elts",
@@ -52891,7 +52895,7 @@
       },
       {
         "name": "model",
-        "type": "Model"
+        "type": "Dynamic_Element"
       },
       {
         "name": "&face_draped_elts",
@@ -52954,7 +52958,7 @@
         "type": "Integer"
       }
     ],
-    "description": "The Rainfall Temporal Pattern information is part of a 12d Model Rainfall File (that ends in \".12dhdyro\"). The Rainfall Files can be created and/or edited by the 12d Model Rainfall File Editor: Water->Stormwater tools->Rainfall editor. 12d Model comes with some Rainfall Files and others can be created by users. The rainfall Temporal Patterns transform the constant average rainfall to a time varied rainfall. The Get_rainfall_temporal_patterns_enabled call returns a Dynamic_Integer list of storm numbers for all the enabled storm patterns in a Rainfall File. These storm numbers are used to retrieve the full storm data via the call\uf020 \uf020 Get_rainfall_temporal_pattern(Text rainfall_filename,Integer storm_num,Integer &run,Text &zone_filter,Real &duration,Real &from_ari,Real &to_ari,Real &interval,Real pattern[],Integer max_num,Integer &ret_num) The image below table is the is of the rainfall Temporal Patterns from the \"AUS ACT Canberra.12dhydro\" file loaded into the Rainfall File Editor. 12d hydro flag to say Zone total length Average Recurrence file name run storm filter of storm Interval (ARI) from to Storm number Storm name or Storm ID Temporal Patterns in the Rainfall File The function arguments are: rainfall_filename is the local name of the \".12dhydro\" file to get the temporal pattern values from. Page 1198 General Chapter min_freq the From ARI value must match this argument. max_freq the To ARI value must match this argument. storms is a Dynamic_Integer list of storm numbers where the Run storm is selected. These numbers are used in the following call to retrieve the full storm data.\uf020 \uf020 Get_rainfall_temporal_pattern(Text rainfall_filename,Integer storm_num,Integer &run,Text &zone_filter,Real &duration,Real &from_ari,Real &to_ari,Real &interval,Real pattern[],Integer max_num,Integer &ret_num) ret_num returns the actual number of storms returned A function return value of zero indicates the data was successfully returned."
+    "description": "The Rainfall Temporal Pattern information is part of a 12d Model Rainfall File (that ends in \".12dhdyro\"). The Rainfall Files can be created and/or edited by the 12d Model Rainfall File Editor: Water->Stormwater tools->Rainfall editor. 12d Model comes with some Rainfall Files and others can be created by users. The rainfall Temporal Patterns transform the constant average rainfall to a time varied rainfall. The Get_rainfall_temporal_patterns_enabled call returns a Dynamic_Integer list of storm numbers for all the enabled storm patterns in a Rainfall File. These storm numbers are used to retrieve the full storm data via the call  Get_rainfall_temporal_pattern(Text rainfall_filename,Integer storm_num,Integer &run,Text &zone_filter,Real &duration,Real &from_ari,Real &to_ari,Real &interval,Real pattern[],Integer max_num,Integer &ret_num) The image below table is the is of the rainfall Temporal Patterns from the \"AUS ACT Canberra.12dhydro\" file loaded into the Rainfall File Editor. 12d hydro flag to say Zone total length Average Recurrence file name run storm filter of storm Interval (ARI) from to Storm number Storm name or Storm ID Temporal Patterns in the Rainfall File The function arguments are: rainfall_filename is the local name of the \".12dhydro\" file to get the temporal pattern values from. Page 1198 General Chapter min_freq the From ARI value must match this argument. max_freq the To ARI value must match this argument. storms is a Dynamic_Integer list of storm numbers where the Run storm is selected. These numbers are used in the following call to retrieve the full storm data.  Get_rainfall_temporal_pattern(Text rainfall_filename,Integer storm_num,Integer &run,Text &zone_filter,Real &duration,Real &from_ari,Real &to_ari,Real &interval,Real pattern[],Integer max_num,Integer &ret_num) ret_num returns the actual number of storms returned A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Get_rainfall_temporal_pattern",
@@ -53006,7 +53010,7 @@
         "type": "Integer"
       }
     ],
-    "description": "The Rainfall Temporal Pattern information is part of a 12d Model Rainfall File (that ends in \".12dhdyro\"). The Rainfall Files can be created and/or edited by the 12d Model Rainfall File Editor: Water->Stormwater tools->Rainfall editor. 12d Model comes with some Rainfall Files and others can be created by users. The rainfall Temporal Patterns transform the constant average rainfall to a time varied rainfall. The Get_rainfall_temporal_pattern call returns the information for one storm from the rainfall Temporal Patterns in a Rainfall File. The image below table is the is of the rainfall Temporal Patterns from the \"AUS ACT Canberra.12dhydro\" file loaded into the Rainfall File Editor. 12d hydro flag to say Zone total length Average Recurrence file name run storm filter of storm Interval (ARI) from to Storm number Storm name or Storm ID Temporal Patterns in the Rainfall File Page 1200 General Chapter interval temporal pattern values file name Temporal Pattern Table from the Rainfall File The function arguments are: rainfall_filename is the local name of the \".12dhydro\" file to get the temporal pattern values from. storm_num is the number of the storm in the file. With the addition of the frequent, intermediate and rare temporal patterns all the storms are combined into one list in the order they appear in the editor. The storm number in the index on this list. The rest of the arguments of the call return values from the storm_num\u2019th line of the Temporal Pattern table. run returns 1 if \"Run Storm\" is ticked 0 if \"Run Storm\" is not ticked zone_filter returns the value from \"Zone Filter\" duration returns the total length of the storm from_ari returns the \"from ARI\" (Average Recurrence Interval, also known as the Frequency or Return Period) to_ari returns the \"to ARI\" (Average Recurrence Interval, also known as the Frequency or Return Period) interval returns the time interval for each of the values in the temporal patterns table (which give the percentage of the total storm that occurs in that period) pattern[ ] is an array to return the values of the temporal pattern max_num is the maximum size of the array pattern[] ret_num returns the actual number of values returned in pattern A function return value of zero indicates the data was successfully returned."
+    "description": "The Rainfall Temporal Pattern information is part of a 12d Model Rainfall File (that ends in \".12dhdyro\"). The Rainfall Files can be created and/or edited by the 12d Model Rainfall File Editor: Water->Stormwater tools->Rainfall editor. 12d Model comes with some Rainfall Files and others can be created by users. The rainfall Temporal Patterns transform the constant average rainfall to a time varied rainfall. The Get_rainfall_temporal_pattern call returns the information for one storm from the rainfall Temporal Patterns in a Rainfall File. The image below table is the is of the rainfall Temporal Patterns from the \"AUS ACT Canberra.12dhydro\" file loaded into the Rainfall File Editor. 12d hydro flag to say Zone total length Average Recurrence file name run storm filter of storm Interval (ARI) from to Storm number Storm name or Storm ID Temporal Patterns in the Rainfall File Page 1200 General Chapter interval temporal pattern values file name Temporal Pattern Table from the Rainfall File The function arguments are: rainfall_filename is the local name of the \".12dhydro\" file to get the temporal pattern values from. storm_num is the number of the storm in the file. With the addition of the frequent, intermediate and rare temporal patterns all the storms are combined into one list in the order they appear in the editor. The storm number in the index on this list. The rest of the arguments of the call return values from the storm_num’th line of the Temporal Pattern table. run returns 1 if \"Run Storm\" is ticked 0 if \"Run Storm\" is not ticked zone_filter returns the value from \"Zone Filter\" duration returns the total length of the storm from_ari returns the \"from ARI\" (Average Recurrence Interval, also known as the Frequency or Return Period) to_ari returns the \"to ARI\" (Average Recurrence Interval, also known as the Frequency or Return Period) interval returns the time interval for each of the values in the temporal patterns table (which give the percentage of the total storm that occurs in that period) pattern[ ] is an array to return the values of the temporal pattern max_num is the maximum size of the array pattern[] ret_num returns the actual number of values returned in pattern A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Get_rainfall_temporal_pattern",
@@ -53714,7 +53718,7 @@
   },
   {
     "name": "Polygons_clip",
-    "id": 543,
+    "id": 1440,
     "returnType": "Integer",
     "parameters": [
       {
@@ -53739,7 +53743,7 @@
       },
       {
         "name": "&npts_out",
-        "type": "Integer"
+        "type": "Real"
       },
       {
         "name": "xarray_out[]",
@@ -53747,10 +53751,18 @@
       },
       {
         "name": "yarray_out[]",
-        "type": "Real"
+        "type": "Integer"
       },
       {
         "name": "yarray_out[]",
+        "type": "Real"
+      },
+      {
+        "name": "yarray_out",
+        "type": "Real"
+      },
+      {
+        "name": "yarray_out",
         "type": "Real"
       }
     ],
@@ -53827,7 +53839,7 @@
       },
       {
         "name": "&npts_out",
-        "type": "Integer"
+        "type": "Real"
       },
       {
         "name": "xarray_out[]",
@@ -53835,6 +53847,14 @@
       },
       {
         "name": "yarray_out[]",
+        "type": "Integer"
+      },
+      {
+        "name": "xarray_out",
+        "type": "Real"
+      },
+      {
+        "name": "yarray_out",
         "type": "Real"
       }
     ],
@@ -53906,7 +53926,7 @@
         "type": "Element"
       }
     ],
-    "description": "This call places a mesh on the vertex of a new super string, at the co-ordinate specified by parameters x, y, z. The source_type determines where the mesh will be loaded from: \uf020 source_type = 0 for the Mesh Library\uf020 , 1 for from a file The source_name specifies the name of the mesh in the library or file, as defined by the source_type parameter. You can also set any additional offset, rotation or scale parameters in the offset, rotate or scale vectors. If you are not intending to set additional parameters, you must set them to at least default values: offset(0.0, 0.0, 0.0)\uf020 rotate(0.0, 0.0, 0.0)\uf020 scale(1.0, 1.0, 1.0); The created super string will be stored in the element mesh_string. This function returns 0 if it succeeds and non zero if it fails."
+    "description": "This call places a mesh on the vertex of a new super string, at the co-ordinate specified by parameters x, y, z. The source_type determines where the mesh will be loaded from:  source_type = 0 for the Mesh Library , 1 for from a file The source_name specifies the name of the mesh in the library or file, as defined by the source_type parameter. You can also set any additional offset, rotation or scale parameters in the offset, rotate or scale vectors. If you are not intending to set additional parameters, you must set them to at least default values: offset(0.0, 0.0, 0.0) rotate(0.0, 0.0, 0.0) scale(1.0, 1.0, 1.0); The created super string will be stored in the element mesh_string. This function returns 0 if it succeeds and non zero if it fails."
   },
   {
     "name": "Place_mesh",
@@ -53950,7 +53970,7 @@
         "type": "Element"
       }
     ],
-    "description": "This call places a mesh from the mesh library on the vertex of a new super string, at the co-ordinate specified by parameters x, y, z and anchors it to the tin anchor_tin. The Text mesh_name specifies the name of the mesh in the library. You can also set any additional offset, rotation or scale parameters in the offset, rotate or scale vectors. If you are not intending to set additional parameters, you must set them to at least default values: offset(0.0, 0.0, 0.0)\uf020 rotate(0.0, 0.0, 0.0)\uf020 scale(1.0, 1.0, 1.0); The created super string will be stored in the Element mesh_string. This function returns 0 if it succeeds and non zero if it fails."
+    "description": "This call places a mesh from the mesh library on the vertex of a new super string, at the co-ordinate specified by parameters x, y, z and anchors it to the tin anchor_tin. The Text mesh_name specifies the name of the mesh in the library. You can also set any additional offset, rotation or scale parameters in the offset, rotate or scale vectors. If you are not intending to set additional parameters, you must set them to at least default values: offset(0.0, 0.0, 0.0) rotate(0.0, 0.0, 0.0) scale(1.0, 1.0, 1.0); The created super string will be stored in the Element mesh_string. This function returns 0 if it succeeds and non zero if it fails."
   },
   {
     "name": "Get_image_size",
@@ -54414,11 +54434,11 @@
       },
       {
         "name": "&e_tun_ele_idx",
-        "type": "Dynamic_Integer"
+        "type": "Dynamic_Text"
       },
       {
         "name": "&e_tun_ele_dist",
-        "type": "Dynamic_Real"
+        "type": "Dynamic_Integer"
       },
       {
         "name": "&e_tun_ele_per",
@@ -54450,7 +54470,7 @@
       },
       {
         "name": "&pd_status_3d",
-        "type": "Dynamic_Integer"
+        "type": "Dynamic_Real"
       },
       {
         "name": "&pd_status_2d",
@@ -54458,10 +54478,14 @@
       },
       {
         "name": "&pd_ref_ch",
-        "type": "Dynamic_Real"
+        "type": "Dynamic_Integer"
       },
       {
         "name": "&message",
+        "type": "Dynamic_Real"
+      },
+      {
+        "name": "message",
         "type": "Text"
       }
     ],
@@ -55058,10 +55082,14 @@
       },
       {
         "name": "call_inverse",
-        "type": "Integer"
+        "type": "Real"
       },
       {
         "name": "&ele",
+        "type": "Integer"
+      },
+      {
+        "name": "ele",
         "type": "Element"
       }
     ],
@@ -55282,6 +55310,10 @@
       },
       {
         "name": "carto_file_name",
+        "type": "Text"
+      },
+      {
+        "name": "datum_data",
         "type": "Text"
       }
     ],
@@ -55846,7 +55878,7 @@
       },
       {
         "name": "user_poly",
-        "type": "Element"
+        "type": "Dynamic_Element"
       },
       {
         "name": "&ret_inside",
@@ -56593,22 +56625,6 @@
     "returnType": "Integer",
     "parameters": [
       {
-        "name": "tin",
-        "type": "Tin"
-      },
-      {
-        "name": "&disk_name",
-        "type": "Text"
-      }
-    ],
-    "description": "Get disk file name of given tin and set it to Text disk_name A function return value of zero indicates the call was successfully."
-  },
-  {
-    "name": "Get_disk_file_name",
-    "id": 7616,
-    "returnType": "Integer",
-    "parameters": [
-      {
         "name": "f",
         "type": "Function"
       },
@@ -56621,7 +56637,7 @@
   },
   {
     "name": "Get_disk_file_name",
-    "id": 7617,
+    "id": 7616,
     "returnType": "Integer",
     "parameters": [
       {
@@ -57174,7 +57190,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Macro_Function func, return the name of the i\u2019th dependencies in name. A function return value of zero indicates the name was successfully returned."
+    "description": "For the Macro_Function func, return the name of the i’th dependencies in name. A function return value of zero indicates the name was successfully returned."
   },
   {
     "name": "Get_dependancy_type",
@@ -57194,7 +57210,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Macro_Function func, return the type of the i\u2019th dependencies as the Text type. The valid types are: 12d Model Macro_Functions Page 1281 12d Model Macro Manual unknown File Element Model Template Tin Integer Real Text A function return value of zero indicates the type was successfully returned."
+    "description": "For the Macro_Function func, return the type of the i’th dependencies as the Text type. The valid types are: 12d Model Macro_Functions Page 1281 12d Model Macro Manual unknown File Element Model Template Tin Integer Real Text A function return value of zero indicates the type was successfully returned."
   },
   {
     "name": "Get_dependancy_file",
@@ -57214,7 +57230,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Macro_Function func, if the i\u2019th dependency is a file then return the name of the file in name. If the i\u2019th dependency is not a file then a non-zero function return value is returned. A function return value of zero indicates the file name was successfully returned."
+    "description": "For the Macro_Function func, if the i’th dependency is a file then return the name of the file in name. If the i’th dependency is not a file then a non-zero function return value is returned. A function return value of zero indicates the file name was successfully returned."
   },
   {
     "name": "Get_dependancy_model",
@@ -57234,7 +57250,7 @@
         "type": "Model"
       }
     ],
-    "description": "For the Macro_Function func, if the i\u2019th dependency is a Model then return the Model in model. If the i\u2019th dependency is not a Model then a non-zero function return value is returned. A function return value of zero indicates the Model was successfully returned."
+    "description": "For the Macro_Function func, if the i’th dependency is a Model then return the Model in model. If the i’th dependency is not a Model then a non-zero function return value is returned. A function return value of zero indicates the Model was successfully returned."
   },
   {
     "name": "Get_dependancy_tin",
@@ -57254,7 +57270,7 @@
         "type": "Tin"
       }
     ],
-    "description": "For the Macro_Function func, if the i\u2019th dependency is a Tin then return the Tin in tin. If the i\u2019th dependency is not a Tin then a non-zero function return value is returned. A function return value of zero indicates the Tin was successfully returned."
+    "description": "For the Macro_Function func, if the i’th dependency is a Tin then return the Tin in tin. If the i’th dependency is not a Tin then a non-zero function return value is returned. A function return value of zero indicates the Tin was successfully returned."
   },
   {
     "name": "Get_dependancy_element",
@@ -57274,7 +57290,7 @@
         "type": "Element"
       }
     ],
-    "description": "For the Macro_Function func, if the i\u2019th dependency is an Element then return the Element in elt. If the i\u2019th dependency is not an Element then a non-zero function return value is returned. A function return value of zero indicates the Element was successfully returned."
+    "description": "For the Macro_Function func, if the i’th dependency is an Element then return the Element in elt. If the i’th dependency is not an Element then a non-zero function return value is returned. A function return value of zero indicates the Element was successfully returned."
   },
   {
     "name": "Get_dependancy_data",
@@ -57294,7 +57310,7 @@
         "type": "Text"
       }
     ],
-    "description": "For the Macro_Function func, a text description of the i\u2019th dependency is returned in text. For an Element, the text description is: model_name->element_name is return in text. For a File/Model/Template/Tin, the text description is the name of the File/Model/Template/Tin. For an Integer, the text description is the Integer converted to Text. For a Real, the text description is the Real converted to Text. LJG? how many decimals For a Text, the text description is just the text. A function return value of zero indicates the Macro_Function description was successfully returned."
+    "description": "For the Macro_Function func, a text description of the i’th dependency is returned in text. For an Element, the text description is: model_name->element_name is return in text. For a File/Model/Template/Tin, the text description is the name of the File/Model/Template/Tin. For an Integer, the text description is the Integer converted to Text. For a Real, the text description is the Real converted to Text. LJG? how many decimals For a Text, the text description is just the text. A function return value of zero indicates the Macro_Function description was successfully returned."
   },
   {
     "name": "Get_dependancy_type",
@@ -57510,7 +57526,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For an Element elt, check if it has a function Uid and if it has, return it in id. If the element doesn\u2019t have a function Uid, id will be set as null. A function return value of zero indicates the Uid was successfully returned."
+    "description": "For an Element elt, check if it has a function Uid and if it has, return it in id. If the element doesn’t have a function Uid, id will be set as null. A function return value of zero indicates the Uid was successfully returned."
   },
   {
     "name": "Set_function_id",
@@ -58073,7 +58089,7 @@
     "id": 2726,
     "returnType": "Function_Property_Collection",
     "parameters": [],
-    "description": "Create a Function_Property_Collection. Function_Property_Collection\u2019s are used to transfer information about a function such as the Apply Many function instead of needing a large number of function calls which would need to be updated every time a new parameter was added to the Apply Many, The function return value is the created Function_Property_Collection."
+    "description": "Create a Function_Property_Collection. Function_Property_Collection’s are used to transfer information about a function such as the Apply Many function instead of needing a large number of function calls which would need to be updated every time a new parameter was added to the Apply Many, The function return value is the created Function_Property_Collection."
   },
   {
     "name": "Set_property",
@@ -58093,7 +58109,7 @@
         "type": "Integer"
       }
     ],
-    "description": "In the Function Property Collection collection, set the value of the Integer property called name to int_val. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn\u2019t exist or it is not Integer property. A function return value of zero indicates the value is successfully set."
+    "description": "In the Function Property Collection collection, set the value of the Integer property called name to int_val. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn’t exist or it is not Integer property. A function return value of zero indicates the value is successfully set."
   },
   {
     "name": "Set_property",
@@ -58113,7 +58129,7 @@
         "type": "Real"
       }
     ],
-    "description": "In the Function Property Collection collection, set the value of the Real property called name to real_val. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn\u2019t exist or it is not Real property. A function return value of zero indicates the value is successfully set."
+    "description": "In the Function Property Collection collection, set the value of the Real property called name to real_val. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn’t exist or it is not Real property. A function return value of zero indicates the value is successfully set."
   },
   {
     "name": "Set_property",
@@ -58133,7 +58149,7 @@
         "type": "Text"
       }
     ],
-    "description": "12d Model Macro_Functions Page 1307 12d Model Macro Manual In the Function Property Collection collection, set the value of the Text property called name to txt_val. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn\u2019t exist or it is not Text property. A function return value of zero indicates the value is successfully set."
+    "description": "12d Model Macro_Functions Page 1307 12d Model Macro Manual In the Function Property Collection collection, set the value of the Text property called name to txt_val. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn’t exist or it is not Text property. A function return value of zero indicates the value is successfully set."
   },
   {
     "name": "Set_property_colour",
@@ -58153,7 +58169,7 @@
         "type": "Text"
       }
     ],
-    "description": "In the Function Property Collection collection, set the value of the Colour property called name to the colour given by colour_name. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn\u2019t exist or it is not Text property. A function return value of zero indicates the value is successfully set."
+    "description": "In the Function Property Collection collection, set the value of the Colour property called name to the colour given by colour_name. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn’t exist or it is not Text property. A function return value of zero indicates the value is successfully set."
   },
   {
     "name": "Set_property",
@@ -58173,7 +58189,7 @@
         "type": "Element"
       }
     ],
-    "description": "In the Function Property Collection collection, set the value of the Element property called name to element. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn\u2019t exist or it is not Element property. A function return value of zero indicates the value is successfully set."
+    "description": "In the Function Property Collection collection, set the value of the Element property called name to element. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn’t exist or it is not Element property. A function return value of zero indicates the value is successfully set."
   },
   {
     "name": "Set_property",
@@ -58193,7 +58209,7 @@
         "type": "Tin"
       }
     ],
-    "description": "In the Function Property Collection collection, set the tin of the Tin property called name to tin. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn\u2019t exist or it is not Tin property. A function return value of zero indicates the value is successfully set. Page 1308 12d Model Macro_Functions Chapter"
+    "description": "In the Function Property Collection collection, set the tin of the Tin property called name to tin. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn’t exist or it is not Tin property. A function return value of zero indicates the value is successfully set. Page 1308 12d Model Macro_Functions Chapter"
   },
   {
     "name": "Set_property",
@@ -58213,7 +58229,7 @@
         "type": "Model"
       }
     ],
-    "description": "In the Function Property Collection collection, set the model of the Model property called name to model. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn\u2019t exist or it is not Model property. A function return value of zero indicates the value is successfully set."
+    "description": "In the Function Property Collection collection, set the model of the Model property called name to model. For more information on which properties are available for the function in question, please see the section Function Properties. The return value is zero if name doesn’t exist or it is not Model property. A function return value of zero indicates the value is successfully set."
   },
   {
     "name": "Get_property",
@@ -58825,7 +58841,7 @@
         "type": "Undo"
       }
     ],
-    "description": "Get the n\u2019th item from the Undo_List undo_list and return the item (which is an Undo) as undo. A function return value of zero indicates the Undo was successfully returned."
+    "description": "Get the n’th item from the Undo_List undo_list and return the item (which is an Undo) as undo. A function return value of zero indicates the Undo was successfully returned."
   },
   {
     "name": "Set_item",
@@ -58845,7 +58861,7 @@
         "type": "Undo"
       }
     ],
-    "description": "Set the n\u2019th item in the Undo_List undo_list to be the Undo undo. A function return value of zero indicates the Undo was successfully set."
+    "description": "Set the n’th item in the Undo_List undo_list to be the Undo undo. A function return value of zero indicates the Undo was successfully set."
   },
   {
     "name": "Append",
@@ -58893,7 +58909,7 @@
         "type": "Undo_List"
       }
     ],
-    "description": "Adds the Undo_List list to the 12d Model Undo system and gives it the name name. At the same time, it automatically removes each of the Undo\u2019s in list from the 12d Model Undo system. So all the items in list are removed from the 12d Model Undo system and replaced by the one item called name."
+    "description": "Adds the Undo_List list to the 12d Model Undo system and gives it the name name. At the same time, it automatically removes each of the Undo’s in list from the 12d Model Undo system. So all the items in list are removed from the 12d Model Undo system and replaced by the one item called name."
   },
   {
     "name": "Create_ODBC_connection",
@@ -59028,7 +59044,7 @@
       },
       {
         "name": "return_as",
-        "type": "Text\uf020"
+        "type": "Text"
       }
     ],
     "description": "This call adds a result column that belongs to a given table to the query. Note that the table must already be added for this to work. The query will retrieve that column from the supplied table when it runs, but in the results it will be called by the name you supply. The call returns 0 if successful."
@@ -59052,7 +59068,7 @@
       },
       {
         "name": "sort_ascending",
-        "type": "Integer\uf020"
+        "type": "Integer"
       }
     ],
     "description": "This call will instruct the query to order the results for a column in a table. Set sort_ascending to 1 if you wish the results to be sorted in ascending order. This call returns 0 if successful."
@@ -59252,26 +59268,6 @@
       }
     ],
     "description": "This call will retrieve a text value from a Database_Result, from the column named by the argument column. The value will be stored in res. This call will return 0 if successful."
-  },
-  {
-    "name": "Get_result_column",
-    "id": 2521,
-    "returnType": "Integer",
-    "parameters": [
-      {
-        "name": "result",
-        "type": "Database_Result"
-      },
-      {
-        "name": "result",
-        "type": "Database_Result"
-      },
-      {
-        "name": "column",
-        "type": "Text"
-      }
-    ],
-    "description": "This call will retrieve an Integer value from a Database_Result, from the column named by the argument column. The value will be stored in res. This call will return 0 if successful."
   },
   {
     "name": "Get_result_column",
@@ -59626,46 +59622,6 @@
     "description": "This call creates and returns a Value Condition Query Condition for a given table, column, operation Page 1344 ODBC Macro Calls Chapter and Text value. See the list of operators for available values of operator. When executed, the data provider will check that the value in column colum_name inside table table_name matches (as appropriate for the given operator) against the supplied value."
   },
   {
-    "name": "Create_value_condition",
-    "id": 2556,
-    "returnType": "Query_Condition",
-    "parameters": [
-      {
-        "name": "table_name",
-        "type": "Text"
-      },
-      {
-        "name": "column_name",
-        "type": "Text"
-      },
-      {
-        "name": "operator",
-        "type": "Integer"
-      }
-    ],
-    "description": "This call creates and returns a Value Condition Query Condition for a given table, column, operation and Integer value. See the list of operators for available values of operator. When executed, the data provider will check that the value in column colum_name inside table table_name matches (as appropriate for the given operator) against the supplied value."
-  },
-  {
-    "name": "Create_value_condition",
-    "id": 2557,
-    "returnType": "Query_Condition",
-    "parameters": [
-      {
-        "name": "table_name",
-        "type": "Text"
-      },
-      {
-        "name": "column_name",
-        "type": "Text"
-      },
-      {
-        "name": "operator",
-        "type": "Integer"
-      }
-    ],
-    "description": "This call creates and returns a Value Condition Query Condition for a given table, column, operation and Real value. See the list of operators for available values of operator. When executed, the data provider will check that the value in column colum_name inside table table_name matches (as appropriate for the given operator) against the supplied value."
-  },
-  {
     "name": "Create_time_value_condition",
     "id": 2558,
     "returnType": "Query_Condition",
@@ -59732,6 +59688,10 @@
       },
       {
         "name": "sub_query",
+        "type": "Integer"
+      },
+      {
+        "name": "sub_query",
         "type": "Select_Query"
       }
     ],
@@ -59752,7 +59712,7 @@
       },
       {
         "name": "not_in",
-        "type": "Integer\uf020"
+        "type": "Integer"
       },
       {
         "name": "values",
@@ -59776,7 +59736,7 @@
       },
       {
         "name": "not_in",
-        "type": "Integer\uf020"
+        "type": "Integer"
       },
       {
         "name": "values",
@@ -60340,18 +60300,6 @@
       }
     ],
     "description": "Synchronize all shared in models of the current project. Any error message will be returned in return_message. A function return value of zero indicates the get operation was successful."
-  },
-  {
-    "name": "Synchronize_all_share_in_tins",
-    "id": 7793,
-    "returnType": "Integer",
-    "parameters": [
-      {
-        "name": "&return_message",
-        "type": "Text"
-      }
-    ],
-    "description": "Synchronize all shared in tins of the current project. Any error message will be returned in return_message. A function return value of zero indicates the get operation was successful."
   },
   {
     "name": "Synchronize_all_master_share_ins",
@@ -60943,6 +60891,10 @@
       {
         "name": "&are_unique_names_case_insensitive",
         "type": "Integer"
+      },
+      {
+        "name": "are_unique_names_case_insensitive",
+        "type": "Integer"
       }
     ],
     "description": "Check for unique name for each element type at the top level of drainage string node (pit) attributes from a Dynamic_Element els. A function return value of zero indicates the get operation was successful."
@@ -61293,7 +61245,7 @@
         "type": "Uid"
       }
     ],
-    "description": "For the macro, if the attribute called att_name does not exist then create it as type Uid and give it the value uid.\uf020 if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the macro, if the attribute called att_name does not exist then create it as type Uid and give it the value uid. if the attribute called att_name does exist and it is type Uid, then set its value to uid. If the attribute exists and is not of type Uid then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_macro_attribute",
@@ -61309,7 +61261,7 @@
         "type": "Attributes"
       }
     ],
-    "description": "For the macro,\uf020 if the attribute called att_name does not exist then create it as type Attributes and give it the value att.\uf020 if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
+    "description": "For the macro, if the attribute called att_name does not exist then create it as type Attributes and give it the value att. if the attribute called att_name does exist and it is type Attributes, then set its value to att. If the attribute exists and is not of type Attributes then a non-zero return value is returned. A function return value of zero indicates the attribute value is successfully set. Note - the Get_attribute_type call can be used to get the type of the attribute called att_name."
   },
   {
     "name": "Set_macro_attribute",
@@ -61385,7 +61337,7 @@
   },
   {
     "name": "Macro_attribute_delete",
-    "id": 3859,
+    "id": 3850,
     "returnType": "Integer",
     "parameters": [
       {
@@ -61444,7 +61396,7 @@
   },
   {
     "name": "Get_macro_attribute_length",
-    "id": 7554,
+    "id": 7555,
     "returnType": "Integer",
     "parameters": [
       {
@@ -61460,7 +61412,7 @@
   },
   {
     "name": "Get_macro_attribute_length",
-    "id": 7555,
+    "id": 7554,
     "returnType": "Integer",
     "parameters": [
       {
@@ -61556,7 +61508,7 @@
   },
   {
     "name": "Get_macro_attribute",
-    "id": 3853,
+    "id": 7543,
     "returnType": "Integer",
     "parameters": [
       {
@@ -61572,7 +61524,7 @@
   },
   {
     "name": "Set_macro_attribute",
-    "id": 3856,
+    "id": 7561,
     "returnType": "Integer",
     "parameters": [
       {

--- a/tests/enrichedFunctions.test.ts
+++ b/tests/enrichedFunctions.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, test } from "bun:test";
+import * as path from "path";
+import * as fs from "fs";
+
+interface FunctionParam {
+	name: string;
+	type: string;
+}
+
+interface FunctionEntry {
+	name: string;
+	id: number;
+	returnType: string;
+	parameters: FunctionParam[];
+	description: string;
+}
+
+const resourcesDir = path.resolve(__dirname, "..", "server", "src", "resources");
+const compilerFunctions: FunctionEntry[] = JSON.parse(
+	fs.readFileSync(path.join(resourcesDir, "functions.compiler.json"), "utf-8")
+);
+const enrichedFunctions: FunctionEntry[] = JSON.parse(
+	fs.readFileSync(path.join(resourcesDir, "functions.enriched.json"), "utf-8")
+);
+
+// Build a lookup from compiler: keyed by lowercase name → array of overloads
+const compilerByName = new Map<string, FunctionEntry[]>();
+for (const fn of compilerFunctions) {
+	const key = fn.name.toLowerCase();
+	const existing = compilerByName.get(key);
+	if (existing) {
+		existing.push(fn);
+	} else {
+		compilerByName.set(key, [fn]);
+	}
+}
+
+function paramSignature(params: FunctionParam[]): string {
+	return params.map((p) => normalizeType(p.type)).join(", ");
+}
+
+/**
+ * Normalize a type string for comparison: trim whitespace and strip
+ * non-ASCII characters (e.g., U+F020 from PDF extraction artifacts).
+ */
+function normalizeType(type: string): string {
+	// eslint-disable-next-line no-control-regex
+	return type.replace(/[^\x20-\x7E]/g, "").trim();
+}
+
+/**
+ * Find the best matching compiler entry for an enriched entry by name.
+ * When there are multiple overloads, pick the one with the closest param signature.
+ */
+function findCompilerMatch(
+	enriched: FunctionEntry
+): { match: FunctionEntry; matchedBy: string } | null {
+	const byName = compilerByName.get(enriched.name.toLowerCase());
+	if (!byName) return null;
+
+	// Exact param signature match
+	const eSig = paramSignature(enriched.parameters);
+	const exactSig = byName.find((c) => paramSignature(c.parameters) === eSig);
+	if (exactSig) return { match: exactSig, matchedBy: "name+params" };
+
+	// Closest by param count
+	const closest = byName.reduce((best, cur) =>
+		Math.abs(cur.parameters.length - enriched.parameters.length) <
+		Math.abs(best.parameters.length - enriched.parameters.length)
+			? cur
+			: best
+	);
+	return { match: closest, matchedBy: "name-only" };
+}
+
+describe("functions.enriched.json validation against functions.compiler.json", () => {
+	test("enriched file is valid JSON with expected structure", () => {
+		expect(Array.isArray(enrichedFunctions)).toBe(true);
+		expect(enrichedFunctions.length).toBeGreaterThan(0);
+
+		for (const fn of enrichedFunctions) {
+			expect(fn).toHaveProperty("name");
+			expect(fn).toHaveProperty("id");
+			expect(fn).toHaveProperty("returnType");
+			expect(fn).toHaveProperty("parameters");
+			expect(fn).toHaveProperty("description");
+			expect(typeof fn.name).toBe("string");
+			expect(typeof fn.id).toBe("number");
+			expect(typeof fn.returnType).toBe("string");
+			expect(Array.isArray(fn.parameters)).toBe(true);
+		}
+	});
+
+	test("every enriched entry has a corresponding compiler entry", () => {
+		const orphaned: string[] = [];
+
+		for (const fn of enrichedFunctions) {
+			const result = findCompilerMatch(fn);
+			if (!result) {
+				orphaned.push(fn.name);
+			}
+		}
+
+		if (orphaned.length > 0) {
+			console.warn(
+				`\n⚠ ${orphaned.length} enriched entries have no compiler match:\n` +
+					orphaned.map((o) => `  - ${o}`).join("\n")
+			);
+		}
+		expect(orphaned).toEqual([]);
+	});
+
+	test("enriched return types match compiler return types", () => {
+		const mismatches: string[] = [];
+
+		for (const fn of enrichedFunctions) {
+			const result = findCompilerMatch(fn);
+			if (!result) continue;
+
+			const { match } = result;
+			if (
+				normalizeType(fn.returnType).toLowerCase() !==
+				normalizeType(match.returnType).toLowerCase()
+			) {
+				mismatches.push(
+					`${fn.name}: enriched="${fn.returnType}" vs compiler="${match.returnType}"`
+				);
+			}
+		}
+
+		if (mismatches.length > 0) {
+			console.warn(
+				`\n⚠ ${mismatches.length} return type mismatches:\n` +
+					mismatches.map((m) => `  - ${m}`).join("\n")
+			);
+		}
+		expect(mismatches).toEqual([]);
+	});
+
+	test("enriched parameter counts match compiler parameter counts", () => {
+		const mismatches: string[] = [];
+
+		for (const fn of enrichedFunctions) {
+			const result = findCompilerMatch(fn);
+			if (!result) continue;
+
+			const { match, matchedBy } = result;
+				if (fn.parameters.length !== match.parameters.length) {
+				mismatches.push(
+					`${fn.name} (matched by ${matchedBy}): ` +
+						`enriched has ${fn.parameters.length} params, compiler has ${match.parameters.length}`
+				);
+			}
+		}
+
+		if (mismatches.length > 0) {
+			console.warn(
+				`\n⚠ ${mismatches.length} parameter count mismatches:\n` +
+					mismatches.map((m) => `  - ${m}`).join("\n")
+			);
+		}
+		expect(mismatches).toEqual([]);
+	});
+
+	test("enriched parameter types match compiler parameter types", () => {
+		const mismatches: string[] = [];
+
+		for (const fn of enrichedFunctions) {
+			const result = findCompilerMatch(fn);
+			if (!result) continue;
+
+			const { match, matchedBy } = result;
+			const minLen = Math.min(
+				fn.parameters.length,
+				match.parameters.length
+			);
+			for (let i = 0; i < minLen; i++) {
+				const eType = fn.parameters[i].type;
+				const cType = match.parameters[i].type;
+				const eNorm = normalizeType(eType);
+				const cNorm = normalizeType(cType);
+
+				if (eNorm.toLowerCase() !== cNorm.toLowerCase()) {
+					mismatches.push(
+						`${fn.name} (matched by ${matchedBy}), param[${i}]: ` +
+							`enriched="${eType}" vs compiler="${cType}"`
+					);
+				}
+			}
+		}
+
+		if (mismatches.length > 0) {
+			console.warn(
+				`\n⚠ ${mismatches.length} parameter type mismatches:\n` +
+					mismatches.map((m) => `  - ${m}`).join("\n")
+			);
+		}
+		expect(mismatches).toEqual([]);
+	});
+
+	test("enriched entries have non-empty descriptions", () => {
+		const empty = enrichedFunctions.filter(
+			(fn) => !fn.description || fn.description.trim().length === 0
+		);
+
+		if (empty.length > 0) {
+			console.warn(
+				`\n⚠ ${empty.length} entries with empty descriptions:\n` +
+					empty.map((fn) => `  - ${fn.name}`).join("\n")
+			);
+		}
+		expect(empty).toEqual([]);
+	});
+
+	test("no hidden/non-ASCII characters in type fields", () => {
+		const issues: string[] = [];
+		// eslint-disable-next-line no-control-regex
+		const nonAsciiRe = /[^\x20-\x7E]/;
+
+		for (const fn of enrichedFunctions) {
+			if (nonAsciiRe.test(fn.returnType)) {
+				issues.push(
+					`${fn.name}: returnType contains non-ASCII chars in "${fn.returnType}"`
+				);
+			}
+			for (let i = 0; i < fn.parameters.length; i++) {
+				if (nonAsciiRe.test(fn.parameters[i].type)) {
+					issues.push(
+						`${fn.name}, param[${i}] "${fn.parameters[i].name}": type contains non-ASCII chars in "${fn.parameters[i].type}"`
+					);
+				}
+				if (nonAsciiRe.test(fn.parameters[i].name)) {
+					issues.push(
+						`${fn.name}, param[${i}]: name contains non-ASCII chars in "${fn.parameters[i].name}"`
+					);
+				}
+			}
+		}
+
+		if (issues.length > 0) {
+			console.warn(
+				`\n\u26a0 ${issues.length} fields with non-ASCII characters (likely PDF extraction artifacts):\n` +
+					issues.map((i) => `  - ${i}`).join("\n")
+			);
+		}
+		expect(issues).toEqual([]);
+	});
+
+	test("no duplicate entries in enriched (same name + same param signature)", () => {
+		const seen = new Map<string, FunctionEntry>();
+		const duplicates: string[] = [];
+
+		for (const fn of enrichedFunctions) {
+			const key = `${fn.name.toLowerCase()}|${paramSignature(fn.parameters)}`;
+			const existing = seen.get(key);
+			if (existing) {
+				duplicates.push(
+					`"${fn.name}" appears multiple times with params (${paramSignature(fn.parameters)})`
+				);
+			} else {
+				seen.set(key, fn);
+			}
+		}
+
+		if (duplicates.length > 0) {
+			console.warn(
+				`\n⚠ ${duplicates.length} duplicate enriched entries:\n` +
+					duplicates.map((d) => `  - ${d}`).join("\n")
+			);
+		}
+		expect(duplicates).toEqual([]);
+	});
+
+	test("summary statistics", () => {
+		const matchResults = {
+			"name+params": 0,
+			"name-only": 0,
+			unmatched: 0,
+		};
+
+		for (const fn of enrichedFunctions) {
+			const result = findCompilerMatch(fn);
+			if (result) {
+				matchResults[result.matchedBy as keyof typeof matchResults]++;
+			} else {
+				matchResults.unmatched++;
+			}
+		}
+
+		const uniqueCompilerNames = new Set(
+			compilerFunctions.map((f) => f.name.toLowerCase())
+		);
+		const uniqueEnrichedNames = new Set(
+			enrichedFunctions.map((f) => f.name.toLowerCase())
+		);
+
+		console.log("\n📊 Enriched vs Compiler Summary:");
+		console.log(`  Compiler entries: ${compilerFunctions.length} (${uniqueCompilerNames.size} unique names)`);
+		console.log(`  Enriched entries: ${enrichedFunctions.length} (${uniqueEnrichedNames.size} unique names)`);
+		console.log(`  Coverage: ${((uniqueEnrichedNames.size / uniqueCompilerNames.size) * 100).toFixed(1)}% of unique compiler function names have enriched docs`);
+		console.log(`  Match breakdown:`);
+		for (const [method, count] of Object.entries(matchResults)) {
+			if (count > 0) console.log(`    ${method}: ${count}`);
+		}
+
+		// This test always passes — it's informational
+		expect(true).toBe(true);
+	});
+});


### PR DESCRIPTION
Through testing I found a few function prototypes weren't matching the compilers expected input or the manual.

I've created a test script for checking against the compiler generated json and made some fixes.