### PR TITLE
Added the base compilation target path as an include Dir

### DIFF
--- a/server/src/services/includeUtils.ts
+++ b/server/src/services/includeUtils.ts
@@ -130,6 +130,7 @@ import * as path from 'path';
 		options: IncludeTraversalOptions & { includeDirectories?: string[] } = {}
 	): string[] {
 		const maxFiles = options.maxFiles ?? 500;
+		const entryDir = path.dirname(entryFileFsPath);
 		const visited = new Set<string>();
 		const results: string[] = [];
 
@@ -154,7 +155,7 @@ import * as path from 'path';
 			const includes = extractIncludePaths(text);
 			for (const inc of includes) {
 				if (results.length >= maxFiles) break;
-				const resolved = resolveIncludeToFsPathWithDirs(cur, inc, options.includeDirectories);
+				const resolved = resolveIncludeToFsPathWithDirs(cur, inc, [entryDir, ...(options.includeDirectories ?? [])]);
 				if (!resolved) {
 					console.warn(`Could not resolve include "${inc}" in file "${cur}"`);
 					continue;


### PR DESCRIPTION
Added the base compilation target path as an include directory when searching for valid header files.

This allows header files to reference additional header files relative to the 4dm file.