### PR TITLE
fix: add explicit CodeQL workflow for JavaScript/TypeScript only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,8 +5,6 @@ on:
     branches: [ "main", "dev" ]
   pull_request:
     branches: [ "main", "dev" ]
-  schedule:
-    - cron: '30 5 * * 1'
 
 jobs:
   analyze:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main", "dev" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+  schedule:
+    - cron: '30 5 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: javascript-typescript
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:javascript-typescript"


### PR DESCRIPTION
## Problem

CodeQL run #187 failed because the **default setup** auto-detected C/C++ due to \.h\ fixture files in the repo. The \Analyze (c-cpp)\ job fails since there is no C/C++ build system.

## Fix

Adds an explicit CodeQL workflow that only analyzes \javascript-typescript\.

## Note

After merging, the **CodeQL default setup should be disabled** in Settings → Code security → Code scanning to avoid running both the default and this workflow.