### PR TITLE
fix: suppress false positive undeclared errors on conditional lines and macro arguments

### DIFF
--- a/server/src/core/validation.UndeclaredSymbols.ts
+++ b/server/src/core/validation.UndeclaredSymbols.ts
@@ -22,7 +22,7 @@ import {
 	type SwitchCaseMismatch,
 } from './validation.Common';
 
-export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymbols): Diagnostic[] {
+export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymbols, conditionalLines?: Set<number>): Diagnostic[] {
 	const diagnostics: Diagnostic[] = [];
 	const switchCaseMismatches: SwitchCaseMismatch[] = [];
 
@@ -53,6 +53,9 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 
 	/** Check an identifier usage inline; emit diagnostic if undeclared. */
 	const checkUsage = (text: string, line: number, column: number, isFunctionCall: boolean) => {
+		// Skip identifiers on conditional lines (#if/#ifdef kept branches)
+		if (conditionalLines?.has(line)) return;
+
 		if (lookupSymbol(text)) return;
 		if (isFunctionCall && knownSymbols.functions.has(text)) return;
 		if (knownSymbols.variables.has(text)) return;
@@ -235,6 +238,7 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 			return visitor.visitChildren(ctx);
 		},
 		visitPostfixExpression(ctx: PostfixExpressionContext | any) {
+			let isMacroCall = false;
 			try {
 				const primary = ctx?.primaryExpression?.();
 				const idNode = primary?.Identifier?.();
@@ -246,7 +250,15 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 				if (text && line !== null && column !== null) {
 					checkUsage(text, line, column, !!isFunctionCall);
 				}
+				// Skip argument validation for function-like macro calls
+				if (isFunctionCall && text && knownSymbols.defines.has(text)) {
+					isMacroCall = true;
+				}
 			} catch { /* ignore */ }
+			if (isMacroCall) {
+				// For macro calls, skip argument validation entirely
+				return undefined;
+			}
 			const children: any[] = ctx?.children ?? [];
 			for (const child of children) {
 				if (child && typeof child.accept === 'function') {
@@ -254,11 +266,6 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 					if (!isPrimary) child.accept(visitor);
 				}
 			}
-			try {
-				for (const argList of ctx?.argumentExpressionList_list?.() ?? []) {
-					argList?.accept?.(visitor);
-				}
-			} catch { /* ignore */ }
 			return undefined;
 		},
 		visitPrimaryExpression(ctx: PrimaryExpressionContext | any) {

--- a/server/src/services/diagnosticService.ts
+++ b/server/src/services/diagnosticService.ts
@@ -68,7 +68,8 @@ export class DiagnosticService {
 			const knownSymbols = await this.buildKnownSymbols(uri);
 			const undeclaredDiagnostics = validateUndeclaredIdentifiers(
 				parseResult.tree,
-				knownSymbols
+				knownSymbols,
+				parseResult.conditionalLines
 			);
 			diagnostics.push(...undeclaredDiagnostics);
 

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -41,7 +41,7 @@ function ValidateWithSymbols(text: string, knownSymbols: KnownSymbols): Diagnost
 	const diagnostics: Diagnostic[] = [];
 	diagnostics.push(...validateDeprecatedCalls(result));
 	diagnostics.push(...syntaxDiagnostics(result));
-	diagnostics.push(...validateUndeclaredIdentifiers(result.tree, knownSymbols));
+	diagnostics.push(...validateUndeclaredIdentifiers(result.tree, knownSymbols, result.conditionalLines));
 	return diagnostics;
 }
 
@@ -2839,5 +2839,136 @@ void main()
 		expect(diagnostics.length).toBe(1);
 		expect(diagnostics[0].message).toContain("requires a size");
 		expect(diagnostics[0].message).toContain("models");
+	});
+});
+
+// ─── Conditional lines — false positive suppression ─────────────────────
+
+describe("Conditional line suppression", () => {
+	test("does not flag undeclared identifiers inside #if conditional blocks", () => {
+		const code = `
+#define DEBUG 0
+#if DEBUG == 1
+	Print_line("test");
+#endif
+void main()
+{
+	Integer x = 1;
+}
+`;
+		const diagnostics = ValidateWithSymbols(code, {
+			functions: new Set(),
+			variables: new Set(),
+			defines: new Set(["DEBUG"]),
+		});
+		const undeclaredErrors = diagnostics.filter(d =>
+			d.message.includes("is not declared")
+		);
+		expect(undeclaredErrors.length).toBe(0);
+	});
+
+	test("does not flag undeclared function calls inside #ifdef blocks", () => {
+		const code = `
+#ifdef FEATURE_FLAG
+	some_unknown_function();
+#endif
+void main()
+{
+	Integer x = 1;
+}
+`;
+		const diagnostics = ValidateWithSymbols(code, {
+			functions: new Set(),
+			variables: new Set(),
+			defines: new Set(),
+		});
+		const undeclaredErrors = diagnostics.filter(d =>
+			d.message.includes("is not declared")
+		);
+		expect(undeclaredErrors.length).toBe(0);
+	});
+
+	test("still flags undeclared identifiers outside conditional blocks", () => {
+		const code = `
+#if DEBUG == 1
+	Print_line("test");
+#endif
+void main()
+{
+	Integer x = unknown_var;
+}
+`;
+		const diagnostics = ValidateWithSymbols(code, {
+			functions: new Set(),
+			variables: new Set(),
+			defines: new Set(["DEBUG"]),
+		});
+		const undeclaredErrors = diagnostics.filter(d =>
+			d.message.includes("is not declared")
+		);
+		expect(undeclaredErrors.length).toBe(1);
+		expect(undeclaredErrors[0].message).toContain("unknown_var");
+	});
+});
+
+// ─── Function-like macro argument suppression ────────────────────────────
+
+describe("Function-like macro argument suppression", () => {
+	test("does not flag arguments of function-like macro calls", () => {
+		const code = `
+#define MY_MACRO(x) (1 << (x))
+void main()
+{
+	Integer a = MY_MACRO(SOME_CONSTANT);
+}
+`;
+		const diagnostics = ValidateWithSymbols(code, {
+			functions: new Set(),
+			variables: new Set(),
+			defines: new Set(["MY_MACRO"]),
+		});
+		const undeclaredErrors = diagnostics.filter(d =>
+			d.message.includes("is not declared")
+		);
+		expect(undeclaredErrors.length).toBe(0);
+	});
+
+	test("still flags undeclared arguments of regular function calls", () => {
+		const code = `
+void main()
+{
+	Integer a = some_func(UNKNOWN_ARG);
+}
+`;
+		const diagnostics = ValidateWithSymbols(code, {
+			functions: new Set(["some_func"]),
+			variables: new Set(),
+			defines: new Set(),
+		});
+		const undeclaredErrors = diagnostics.filter(d =>
+			d.message.includes("is not declared")
+		);
+		expect(undeclaredErrors.length).toBe(1);
+		expect(undeclaredErrors[0].message).toContain("UNKNOWN_ARG");
+	});
+
+	test("does not flag arguments of function-like define from include file", () => {
+		const code = `
+#define String_Super_Bit(n) (1 << n)
+#define Att_ZCoord_Value 1
+void main()
+{
+	Integer flag = String_Super_Bit(ZCoord_Value);
+}
+`;
+		const diagnostics = ValidateWithSymbols(code, {
+			functions: new Set(),
+			variables: new Set(),
+			defines: new Set(["String_Super_Bit", "Att_ZCoord_Value"]),
+		});
+		const undeclaredErrors = diagnostics.filter(d =>
+			d.message.includes("is not declared")
+		);
+		expect(undeclaredErrors.length).toBe(0);
 	});
 });


### PR DESCRIPTION
## Problem

The undeclared symbol validator was producing false positive errors in two scenarios:

1. **Conditional lines** (#if/#ifdef blocks): Functions like Print_line inside #if DEBUG == 1 blocks were flagged as undeclared, even though these lines may be conditionally compiled and the symbols may be available at compile time.

2. **Function-like macro arguments**: When calling a function-like #define macro (e.g., String_Super_Bit(ZCoord_Value)), the arguments were validated as standalone identifiers. Since macro arguments are token-pasted, not real variable references, this produced false positives.

Additionally, the isitPostfixExpression visitor was double-visiting argument expression lists, causing duplicate diagnostics.

## Changes

- **alidation.UndeclaredSymbols.ts**: Accept optional conditionalLines parameter; skip validation on conditional lines; skip argument validation for function-like macro calls; fix double-visit of argument expressions
- **diagnosticService.ts**: Pass conditionalLines from parse result through to the undeclared validator
- **alidator.test.ts**: Update ValidateWithSymbols helper to pass conditionalLines; add 6 new test cases (3 for conditional line suppression, 3 for macro argument suppression)

## Testing

All 201 tests pass (201 pass, 0 fail).