### PR TITLE
Control flow checks added

### DIFF
--- a/client/testFixture/control_flow.4dm
+++ b/client/testFixture/control_flow.4dm
@@ -1,0 +1,264 @@
+// Fixture for control flow validation tests
+// Issues #96 (break not in loop/switch), #97 (continue not in loop),
+//        #98 (switch multiple defaults), #99 (switch dead code)
+
+// ─── #96: break not in loop or switch ────────────────────────────────────────
+
+void break_in_while()
+{
+    Integer i = 0;
+    while (i < 10)
+    {
+        if (i == 5)
+            break;       // OK — break inside while loop
+        i = i + 1;
+    }
+}
+
+void break_in_for()
+{
+    Integer i;
+    for (i = 0; i < 10; i = i + 1)
+    {
+        break;           // OK — break inside for loop
+    }
+}
+
+void break_in_do_while()
+{
+    Integer i = 0;
+    do
+    {
+        break;           // OK — break inside do-while loop
+        i = i + 1;
+    } while (i < 10);
+}
+
+void break_in_switch()
+{
+    Integer x = 1;
+    switch (x)
+    {
+        case 1:
+        {
+            break;       // OK — break inside switch
+        }
+        default:
+        {
+            break;       // OK — break inside switch default
+        }
+    }
+}
+
+void break_not_in_loop()
+{
+    break;               // ERROR: break outside loop or switch
+}
+
+void break_not_in_loop_nested_if()
+{
+    Integer x = 1;
+    if (x > 0)
+    {
+        break;           // ERROR: break inside if but not inside loop or switch
+    }
+}
+
+// ─── #97: continue not in loop ───────────────────────────────────────────────
+
+void continue_in_while()
+{
+    Integer i = 0;
+    while (i < 10)
+    {
+        if (i == 5)
+            continue;    // OK — continue inside while loop
+        i = i + 1;
+    }
+}
+
+void continue_in_for()
+{
+    Integer i;
+    for (i = 0; i < 10; i = i + 1)
+    {
+        continue;        // OK — continue inside for loop
+    }
+}
+
+void continue_not_in_loop()
+{
+    continue;            // ERROR: continue outside loop
+}
+
+void continue_not_in_switch()
+{
+    Integer x = 1;
+    switch (x)
+    {
+        default:
+        {
+            continue;    // ERROR: continue inside switch but not inside loop
+        }
+    }
+}
+
+void continue_in_loop_inside_switch()
+{
+    Integer x = 1;
+    switch (x)
+    {
+        default:
+        {
+            Integer i;
+            for (i = 0; i < 5; i = i + 1)
+            {
+                continue;    // OK — continue inside loop that is nested in switch
+            }
+        }
+    }
+}
+
+// ─── #98: switch with more than one default ───────────────────────────────────
+
+void switch_single_default()
+{
+    Text text;
+    switch (text)
+    {
+        case "hello":
+        {
+        }
+        default:
+        {
+        }
+    }
+}
+
+void switch_multiple_defaults()
+{
+    Text text;
+    switch (text)
+    {
+        default:
+        {
+        }
+        default:          // ERROR: second default
+        {
+        }
+    }
+}
+
+void switch_three_defaults()
+{
+    Text text;
+    switch (text)
+    {
+        default:
+        {
+        }
+        default:          // ERROR: second default
+        {
+        }
+        default:          // ERROR: third default
+        {
+        }
+    }
+}
+
+void switch_default_in_nested_switch_ok()
+{
+    Integer x = 1;
+    switch (x)
+    {
+        default:          // OK — first default in outer switch
+        {
+            Integer y = 2;
+            switch (y)
+            {
+                default:  // OK — first default in nested switch (separate switch)
+                {
+                }
+            }
+        }
+    }
+}
+
+// ─── #99: dead code in switch ─────────────────────────────────────────────────
+
+void switch_no_dead_code()
+{
+    Text text;
+    switch (text)
+    {
+        case "hello":
+        {
+        }
+        default:
+        {
+        }
+    }
+}
+
+void switch_dead_code_declaration()
+{
+    Text text;
+    switch (text)
+    {
+        Text dead;        // WARNING: dead code before first case/default
+        default:
+        {
+        }
+    }
+}
+
+void switch_dead_code_statement()
+{
+    Text text;
+    Integer x = 0;
+    switch (text)
+    {
+        x = 1;            // WARNING: dead code before first case/default
+        default:
+        {
+        }
+    }
+}
+
+void switch_dead_code_multiple()
+{
+    Text text;
+    Integer x;
+    switch (text)
+    {
+        x = 1;            // WARNING: dead code #1
+        Text unused;      // WARNING: dead code #2
+        default:
+        {
+        }
+    }
+}
+
+void switch_no_dead_code_after_case()
+{
+    Integer x = 1;
+    switch (x)
+    {
+        case 1:
+        {
+            Integer y;    // OK — declaration inside case block, not dead code
+        }
+        default:
+        {
+        }
+    }
+}
+
+void switch_empty_body()
+{
+    Integer x = 1;
+    switch (x)
+    {
+        // No items — nothing to flag
+    }
+}

--- a/server/src/core/validation.ControlFlow.ts
+++ b/server/src/core/validation.ControlFlow.ts
@@ -1,0 +1,274 @@
+/**
+ * Control flow validation — issues #96, #97, #98, #99.
+ *
+ * #96: 'break' used outside of a loop or switch statement.
+ * #97: 'continue' used outside of a loop.
+ * #98: A switch statement has more than one 'default' label.
+ * #99: Statements or declarations appear before the first case/default
+ *      in a switch body (dead code — never reached).
+ */
+
+import {
+	Diagnostic,
+	DiagnosticSeverity,
+} from 'vscode-languageserver/node';
+
+// Rule indices from the generated parser (proglang12dParser.RULE_*)
+const RULE_SELECTION_STATEMENT = 57;
+const RULE_ITERATION_STATEMENT = 58;
+
+type FlowContext = 'loop' | 'switch';
+
+/**
+ * Collects all four control-flow diagnostics in a single tree traversal.
+ * Must only be called when the parse tree has zero syntax errors.
+ *
+ * @param tree - Root of the ANTLR parse tree.
+ */
+export function validateControlFlow(tree: any): Diagnostic[] {
+	const diagnostics: Diagnostic[] = [];
+	const flowStack: FlowContext[] = [];
+
+	const visitor: any = {
+		visitTerminal() { return undefined; },
+		visitErrorNode() { return undefined; },
+
+		visitChildren(ctx: any) {
+			for (const child of ctx?.children ?? []) {
+				if (child && typeof child.accept === 'function') {
+					child.accept(visitor);
+				}
+			}
+			return undefined;
+		},
+
+		visitIterationStatement(ctx: any) {
+			flowStack.push('loop');
+			visitor.visitChildren(ctx);
+			flowStack.pop();
+			return undefined;
+		},
+
+		visitSelectionStatement(ctx: any) {
+			let isSwitch = false;
+			try { isSwitch = ctx.Switch?.() != null; } catch { /* not a switch */ }
+
+			if (isSwitch) {
+				// Check switch body for dead code (#99) and multiple defaults (#98)
+				checkSwitchBody(ctx, diagnostics);
+				flowStack.push('switch');
+				visitor.visitChildren(ctx);
+				flowStack.pop();
+			} else {
+				visitor.visitChildren(ctx);
+			}
+			return undefined;
+		},
+
+		visitJumpStatement(ctx: any) {
+			let isBreak = false;
+			let isContinue = false;
+			try { isBreak = ctx.Break?.() != null; } catch { /* ignore */ }
+			try { isContinue = ctx.Continue?.() != null; } catch { /* ignore */ }
+
+			if (isBreak) {
+				const inLoopOrSwitch = flowStack.some(c => c === 'loop' || c === 'switch');
+				if (!inLoopOrSwitch) {
+					diagnostics.push(makeTokenDiagnostic(ctx, DiagnosticSeverity.Error,
+						"'break' statement not inside a loop or switch", 'break'.length));
+				}
+			}
+
+			if (isContinue) {
+				const inLoop = flowStack.some(c => c === 'loop');
+				if (!inLoop) {
+					diagnostics.push(makeTokenDiagnostic(ctx, DiagnosticSeverity.Error,
+						"'continue' statement not inside a loop", 'continue'.length));
+				}
+			}
+
+			// No need to recurse — jumpStatement has no nested statements
+			return undefined;
+		},
+	};
+
+	tree.accept(visitor);
+	return diagnostics;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Switch-body checks (#98 and #99)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Checks a switch selectionStatement for:
+ *  - Dead code before the first case/default (#99)
+ *  - More than one default label (#98)
+ */
+function checkSwitchBody(switchCtx: any, diagnostics: Diagnostic[]) {
+	try {
+		// The switch body is the first (and only) statement child
+		const body = getSwitchBodyStatement(switchCtx);
+		if (!body) return;
+
+		const compound = getCompoundStatement(body);
+		if (!compound) return;
+
+		const blockItemList = getBlockItemList(compound);
+		if (!blockItemList) return;
+
+		const blockItems = blockItemList.blockItem_list?.() ?? [];
+
+		// ── #99: dead code before first case/default ──────────────────────────
+		let foundFirstLabel = false;
+		for (const item of blockItems) {
+			if (isBlockItemLabeledCaseOrDefault(item)) {
+				foundFirstLabel = true;
+			} else if (!foundFirstLabel) {
+				// This item precedes any case/default — it is dead code
+				const startLine = (item.start?.line ?? 1) - 1;
+				const startChar = item.start?.column ?? 0;
+				const endLine = (item.stop?.line ?? item.start?.line ?? 1) - 1;
+				const endChar = (item.stop?.column ?? startChar) +
+					(item.stop?.text?.length ?? 1);
+				diagnostics.push({
+					severity: DiagnosticSeverity.Warning,
+					range: {
+						start: { line: startLine, character: startChar },
+						end: { line: endLine, character: endChar },
+					},
+					message: "Dead code: unreachable statement before first 'case' or 'default' in switch",
+				});
+			}
+		}
+
+		// ── #98: more than one default ────────────────────────────────────────
+		const defaultLabels = collectDefaultLabels(compound);
+		for (let i = 1; i < defaultLabels.length; i++) {
+			const def = defaultLabels[i];
+			const line = (def.start?.line ?? 1) - 1;
+			const col = def.start?.column ?? 0;
+			diagnostics.push({
+				severity: DiagnosticSeverity.Error,
+				range: {
+					start: { line, character: col },
+					end: { line, character: col + 'default'.length },
+				},
+				message: "Switch statement has more than one 'default' label",
+			});
+		}
+	} catch { /* ignore malformed trees */ }
+}
+
+/** Returns the statement node that forms the body of a switch selectionStatement. */
+function getSwitchBodyStatement(switchCtx: any): any | null {
+	try {
+		// For `switch (expr) statement`, statement_list() gives all statement children.
+		// The first one is the switch condition, so we need statement(0) which is
+		// the switch body when there is only one statement child.
+		// Actually, per the grammar selectionStatement has expression() and statement().
+		// statement_list() returns all StatementContext children — for switch there is one.
+		const stmts = switchCtx.statement_list?.() ?? [];
+		if (stmts.length > 0) return stmts[0];
+		return switchCtx.statement?.(0) ?? null;
+	} catch { return null; }
+}
+
+/** Unwraps a statement to its compoundStatement, if present. */
+function getCompoundStatement(stmtCtx: any): any | null {
+	try {
+		return stmtCtx.compoundStatement?.() ?? null;
+	} catch { return null; }
+}
+
+/** Returns the blockItemList from a compoundStatement, or null. */
+function getBlockItemList(compoundCtx: any): any | null {
+	try {
+		return compoundCtx.blockItemList?.() ?? null;
+	} catch { return null; }
+}
+
+/**
+ * Returns true if a blockItem is a labeledStatement with 'case' or 'default'.
+ */
+function isBlockItemLabeledCaseOrDefault(blockItem: any): boolean {
+	try {
+		const stmt = blockItem.statement?.();
+		if (!stmt) return false;
+		const labeled = stmt.labeledStatement?.();
+		if (!labeled) return false;
+		const hasCase = (() => { try { return labeled.Case?.() != null; } catch { return false; } })();
+		const hasDefault = (() => { try { return labeled.Default?.() != null; } catch { return false; } })();
+		return hasCase || hasDefault;
+	} catch { return false; }
+}
+
+/**
+ * Collects all 'default' labeledStatement contexts directly inside `compound`,
+ * but does NOT descend into nested switch statements (to avoid counting their defaults).
+ * Does descend into loops and if-blocks.
+ */
+function collectDefaultLabels(compound: any): any[] {
+	const result: any[] = [];
+	walkForDefaults(compound, result);
+	return result;
+}
+
+function walkForDefaults(node: any, result: any[]): void {
+	if (!node) return;
+	const children: any[] = node.children ?? [];
+	for (const child of children) {
+		if (!child || typeof child !== 'object') continue;
+
+		// If this child is a selectionStatement with Switch, stop descending
+		// (it is a nested switch — its defaults belong to a different switch)
+		if (isNestedSwitchSelectionStatement(child)) continue;
+
+		// If this child is a labeledStatement with 'default', record it
+		if (isLabeledStatementWithDefault(child)) {
+			result.push(child);
+			// Still walk inside for nested cases — but since we skip nested
+			// switches, we won't accidentally count their defaults
+		}
+
+		walkForDefaults(child, result);
+	}
+}
+
+/** Returns true if ctx is a selectionStatement (ruleIndex=57) that has a Switch token. */
+function isNestedSwitchSelectionStatement(ctx: any): boolean {
+	try {
+		if (ctx.ruleIndex !== RULE_SELECTION_STATEMENT) return false;
+		return ctx.Switch?.() != null;
+	} catch { return false; }
+}
+
+/** Returns true if ctx is a labeledStatement with a 'default' token. */
+function isLabeledStatementWithDefault(ctx: any): boolean {
+	try {
+		return ctx.Default?.() != null;
+	} catch { return false; }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Creates a diagnostic anchored at ctx.start with the given keyword length. */
+function makeTokenDiagnostic(
+	ctx: any,
+	severity: DiagnosticSeverity,
+	message: string,
+	keywordLength: number
+): Diagnostic {
+	const line = (ctx.start?.line ?? 1) - 1;
+	const col = ctx.start?.column ?? 0;
+	return {
+		severity,
+		range: {
+			start: { line, character: col },
+			end: { line, character: col + keywordLength },
+		},
+		message,
+	};
+}

--- a/server/src/core/validators.ts
+++ b/server/src/core/validators.ts
@@ -21,3 +21,4 @@ export { validateVoidFunctionReturnValues, type OverloadReturnType } from './val
 export { validateFunctionArguments } from './validation.FunctionArguments';
 export type { FunctionSignatureMap } from './validation.FunctionArguments';
 export { validateArraySize } from './validation.ArraySize';
+export { validateControlFlow } from './validation.ControlFlow';

--- a/server/src/services/diagnosticService.ts
+++ b/server/src/services/diagnosticService.ts
@@ -16,7 +16,8 @@ import { validateVariableRedeclarations,
 	validateVoidFunctionReturnValues,
 	validateFunctionArguments,
 	validateReturnStatements,
-	validateArraySize} from '../core/validators';
+	validateArraySize,
+	validateControlFlow} from '../core/validators';
 import type { FunctionSignatureMap, OverloadReturnType } from '../core/validators';
 import type { KnownSymbols, ParameterSymbolInfo } from '../core/types';
 
@@ -98,7 +99,10 @@ export class DiagnosticService {
 			// 3g. Array size validation (issue #73)
 			const arraySizeDiagnostics = validateArraySize(parseResult.tree);
 			diagnostics.push(...arraySizeDiagnostics);
-      
+
+			// 3h. Control flow validation (issues #96, #97, #98, #99)
+			const controlFlowDiagnostics = validateControlFlow(parseResult.tree);
+			diagnostics.push(...controlFlowDiagnostics);
 		}
 
 		return diagnostics;

--- a/tests/controlFlow.test.ts
+++ b/tests/controlFlow.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Tests for control flow validation:
+ *   #96 — break not in loop or switch
+ *   #97 — continue not in loop
+ *   #98 — switch with more than one default
+ *   #99 — dead code (statements before first case/default in switch)
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as path from 'path';
+import * as fs from 'fs';
+import { parse } from '../server/src/core/parsePipeline';
+import { validateControlFlow } from '../server/src/core/validators';
+
+type Diagnostic = { severity: number; range: any; message: string; [key: string]: any };
+
+const ERROR = 1;
+const WARNING = 2;
+
+function validate(text: string): Diagnostic[] {
+	const result = parse(text);
+	if (result.syntaxErrors.length > 0) {
+		throw new Error(`Parse errors: ${result.syntaxErrors.map(e => e.message).join(', ')}`);
+	}
+	return validateControlFlow(result.tree) as Diagnostic[];
+}
+
+/** Returns the subset of diagnostics whose messages include the given substring. */
+function withMessage(diags: Diagnostic[], substr: string): Diagnostic[] {
+	return diags.filter(d => d.message.includes(substr));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #96 — break not in loop or switch
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#96 — break not in loop or switch', () => {
+	test('break inside while loop — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer i = 0;
+    while (i < 10) {
+        break;
+        i = i + 1;
+    }
+}`);
+		expect(withMessage(diags, "break")).toHaveLength(0);
+	});
+
+	test('break inside for loop — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer i;
+    for (i = 0; i < 10; i = i + 1) {
+        break;
+    }
+}`);
+		expect(withMessage(diags, "break")).toHaveLength(0);
+	});
+
+	test('break inside do-while loop — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer i = 0;
+    do {
+        break;
+        i = i + 1;
+    } while (i < 10);
+}`);
+		expect(withMessage(diags, "break")).toHaveLength(0);
+	});
+
+	test('break inside switch — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    switch (x) {
+        case 1: { break; }
+        default: { break; }
+    }
+}`);
+		expect(withMessage(diags, "break")).toHaveLength(0);
+	});
+
+	test('break directly in function body — 1 error', () => {
+		const diags = validate(`
+void fn() {
+    break;
+}`);
+		const err = withMessage(diags, "break");
+		expect(err).toHaveLength(1);
+		expect(err[0].severity).toBe(ERROR);
+		expect(err[0].message).toContain("'break' statement not inside a loop or switch");
+	});
+
+	test('break inside if-block but not in loop — 1 error', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    if (x > 0) {
+        break;
+    }
+}`);
+		const err = withMessage(diags, "break");
+		expect(err).toHaveLength(1);
+		expect(err[0].severity).toBe(ERROR);
+	});
+
+	test('break after loop (outside) — 1 error', () => {
+		const diags = validate(`
+void fn() {
+    Integer i;
+    for (i = 0; i < 10; i = i + 1) {
+    }
+    break;
+}`);
+		const err = withMessage(diags, "break");
+		expect(err).toHaveLength(1);
+		expect(err[0].severity).toBe(ERROR);
+	});
+
+	test('break anchors to the correct line and column', () => {
+		const diags = validate(`
+void fn() {
+    Integer x;
+    break;
+}`);
+		const err = withMessage(diags, "break");
+		expect(err).toHaveLength(1);
+		// Line 3 (0-indexed) is `    break;`
+		expect(err[0].range.start.line).toBe(3);
+		// 4 spaces of indentation
+		expect(err[0].range.start.character).toBe(4);
+		expect(err[0].range.end.character).toBe(4 + 'break'.length);
+	});
+
+	test('break inside nested loop within switch — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    switch (x) {
+        default: {
+            Integer i;
+            for (i = 0; i < 5; i = i + 1) {
+                break;
+            }
+        }
+    }
+}`);
+		expect(withMessage(diags, "'break' statement not inside")).toHaveLength(0);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #97 — continue not in loop
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#97 — continue not in loop', () => {
+	test('continue inside while loop — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer i = 0;
+    while (i < 10) {
+        continue;
+        i = i + 1;
+    }
+}`);
+		expect(withMessage(diags, "continue")).toHaveLength(0);
+	});
+
+	test('continue inside for loop — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer i;
+    for (i = 0; i < 10; i = i + 1) {
+        continue;
+    }
+}`);
+		expect(withMessage(diags, "continue")).toHaveLength(0);
+	});
+
+	test('continue inside do-while loop — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer i = 0;
+    do {
+        continue;
+        i = i + 1;
+    } while (i < 10);
+}`);
+		expect(withMessage(diags, "continue")).toHaveLength(0);
+	});
+
+	test('continue directly in function body — 1 error', () => {
+		const diags = validate(`
+void fn() {
+    continue;
+}`);
+		const err = withMessage(diags, "continue");
+		expect(err).toHaveLength(1);
+		expect(err[0].severity).toBe(ERROR);
+		expect(err[0].message).toContain("'continue' statement not inside a loop");
+	});
+
+	test('continue inside switch (not in loop) — 1 error', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    switch (x) {
+        default: {
+            continue;
+        }
+    }
+}`);
+		const err = withMessage(diags, "continue");
+		expect(err).toHaveLength(1);
+		expect(err[0].severity).toBe(ERROR);
+	});
+
+	test('continue inside loop that is nested in switch — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    switch (x) {
+        default: {
+            Integer i;
+            for (i = 0; i < 5; i = i + 1) {
+                continue;
+            }
+        }
+    }
+}`);
+		expect(withMessage(diags, "'continue' statement not inside")).toHaveLength(0);
+	});
+
+	test('continue anchors to the correct line and column', () => {
+		const diags = validate(`
+void fn() {
+    Integer x;
+    continue;
+}`);
+		const err = withMessage(diags, "continue");
+		expect(err).toHaveLength(1);
+		expect(err[0].range.start.line).toBe(3);
+		expect(err[0].range.start.character).toBe(4);
+		expect(err[0].range.end.character).toBe(4 + 'continue'.length);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #98 — switch with more than one default
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#98 — switch multiple defaults', () => {
+	test('switch with one default — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    switch (t) {
+        case "x": { }
+        default: { }
+    }
+}`);
+		expect(withMessage(diags, "default")).toHaveLength(0);
+	});
+
+	test('switch with two defaults — 1 error on second default', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    switch (t) {
+        default: { }
+        default: { }
+    }
+}`);
+		const err = withMessage(diags, "more than one 'default'");
+		expect(err).toHaveLength(1);
+		expect(err[0].severity).toBe(ERROR);
+	});
+
+	test('switch with three defaults — 2 errors (on 2nd and 3rd)', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    switch (t) {
+        default: { }
+        default: { }
+        default: { }
+    }
+}`);
+		const err = withMessage(diags, "more than one 'default'");
+		expect(err).toHaveLength(2);
+		expect(err[0].severity).toBe(ERROR);
+		expect(err[1].severity).toBe(ERROR);
+	});
+
+	test('nested switch each with one default — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    switch (x) {
+        default: {
+            Integer y = 2;
+            switch (y) {
+                default: { }
+            }
+        }
+    }
+}`);
+		expect(withMessage(diags, "more than one 'default'")).toHaveLength(0);
+	});
+
+	test('outer switch has two defaults, inner has one — 1 error only', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    switch (x) {
+        default: {
+            Integer y = 2;
+            switch (y) {
+                default: { }
+            }
+        }
+        default: { }
+    }
+}`);
+		const err = withMessage(diags, "more than one 'default'");
+		expect(err).toHaveLength(1);
+		expect(err[0].severity).toBe(ERROR);
+	});
+
+	test('second default error anchors to the second default keyword', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    switch (t) {
+        default: { }
+        default: { }
+    }
+}`);
+		const err = withMessage(diags, "more than one 'default'");
+		expect(err).toHaveLength(1);
+		// Second default is on line 5 (0-indexed)
+		expect(err[0].range.start.line).toBe(5);
+		// 8 spaces of indentation
+		expect(err[0].range.start.character).toBe(8);
+		expect(err[0].range.end.character - err[0].range.start.character).toBe('default'.length);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #99 — dead code before first case/default in switch
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#99 — dead code in switch', () => {
+	test('switch with no items before first case — no diagnostic', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    switch (t) {
+        case "x": { }
+        default: { }
+    }
+}`);
+		expect(withMessage(diags, "Dead code")).toHaveLength(0);
+	});
+
+	test('declaration before default — 1 warning', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    switch (t) {
+        Text dead;
+        default: { }
+    }
+}`);
+		const warns = withMessage(diags, "Dead code");
+		expect(warns).toHaveLength(1);
+		expect(warns[0].severity).toBe(WARNING);
+	});
+
+	test('statement before default — 1 warning', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    Integer x = 0;
+    switch (t) {
+        x = 1;
+        default: { }
+    }
+}`);
+		const warns = withMessage(diags, "Dead code");
+		expect(warns).toHaveLength(1);
+		expect(warns[0].severity).toBe(WARNING);
+	});
+
+	test('multiple items before first case — warning per item', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    Integer x;
+    switch (t) {
+        x = 1;
+        Text unused;
+        default: { }
+    }
+}`);
+		const warns = withMessage(diags, "Dead code");
+		expect(warns).toHaveLength(2);
+	});
+
+	test('content inside case block — no dead code warning', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    switch (x) {
+        case 1: {
+            Integer y;
+        }
+        default: { }
+    }
+}`);
+		expect(withMessage(diags, "Dead code")).toHaveLength(0);
+	});
+
+	test('empty switch body — no dead code warning', () => {
+		const diags = validate(`
+void fn() {
+    Integer x = 1;
+    switch (x) {
+    }
+}`);
+		expect(withMessage(diags, "Dead code")).toHaveLength(0);
+	});
+
+	test('dead code warning message is descriptive', () => {
+		const diags = validate(`
+void fn() {
+    Text t;
+    switch (t) {
+        Text dead;
+        default: { }
+    }
+}`);
+		const warns = withMessage(diags, "Dead code");
+		expect(warns[0].message).toContain("case");
+		expect(warns[0].message).toContain("default");
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixture-based smoke test
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('control_flow.4dm fixture', () => {
+	test('fixture parses without syntax errors and produces expected diagnostics', () => {
+		const fixturePath = path.resolve(__dirname, '..', 'client', 'testFixture', 'control_flow.4dm');
+		const text = fs.readFileSync(fixturePath, 'utf-8');
+		const result = parse(text);
+		expect(result.syntaxErrors).toHaveLength(0);
+
+		const diags = validateControlFlow(result.tree) as Diagnostic[];
+
+		// #96 errors: break_not_in_loop (1) + break_not_in_loop_nested_if (1)
+		const breakErrors = diags.filter(d => d.message.includes("'break' statement not inside"));
+		expect(breakErrors.length).toBeGreaterThanOrEqual(2);
+
+		// #97 errors: continue_not_in_loop (1) + continue_not_in_switch (1)
+		const continueErrors = diags.filter(d => d.message.includes("'continue' statement not inside"));
+		expect(continueErrors.length).toBeGreaterThanOrEqual(2);
+
+		// #98 errors: switch_multiple_defaults (1) + switch_three_defaults (2)
+		const defaultErrors = diags.filter(d => d.message.includes("more than one 'default'"));
+		expect(defaultErrors.length).toBeGreaterThanOrEqual(3);
+
+		// #99 warnings: switch_dead_code_declaration (1) + switch_dead_code_statement (1) + switch_dead_code_multiple (2)
+		const deadCodeWarnings = diags.filter(d => d.message.includes("Dead code"));
+		expect(deadCodeWarnings.length).toBeGreaterThanOrEqual(4);
+	});
+});


### PR DESCRIPTION
Adds control flow validation for issues #96, #97, #98, and #99. Detects `break` outside a loop or switch (error), `continue` outside a loop (error), multiple `default` labels in a switch (error), and dead code before the first `case`/`default` in a switch body (warning). Includes 30 unit tests and a fixture file.