### PR TITLE
Add logical-condition validation (#101 & #102)

### DIFF
--- a/client/testFixture/logical_condition.4dm
+++ b/client/testFixture/logical_condition.4dm
@@ -1,0 +1,91 @@
+// ============================================================================
+// logical_condition.4dm - Logical-condition validation (issue #101)
+// ============================================================================
+// Validator: validateLogicalConditions
+//
+// Reports when an `if`, `while`, `do…while`, or `for` test expression
+// has a type that cannot be evaluated as a logical (boolean) value.
+// ============================================================================
+
+// ──────── Compatible conditions (no diagnostics) ───────────────────────────
+
+void test_compatible()
+{
+	Integer i = 0;
+	Real    r = 0.0;
+	Text    t = "hello";
+
+	if (1) {}                       // OK: Integer literal
+	if (i) {}                       // OK: Integer variable
+	if (i < 10) {}                  // OK: relational expression
+
+	while (i < 10)                  // OK: relational expression
+	{
+		i = i + 1;
+	}
+
+	while (i)                       // OK: Integer variable (truthy)
+	{
+		i = i - 1;
+	}
+
+	do
+	{
+		i = i + 1;
+	} while (i < 100);              // OK: relational expression
+
+	for (Integer j = 0; j < 10; j = j + 1) {} // OK: relational
+
+	if (t == "hello") {}            // OK: equality is logical
+	if (i != 0 && r > 0.0) {}       // OK: combined relational
+}
+
+// ──────── Incompatible conditions (issue #101) ─────────────────────────────
+
+void test_incompatible_while_literal()
+{
+	while ("123")                   // ERROR: Cannot use 'Text' as a logical condition
+	{
+	}
+}
+
+void test_incompatible_while_var()
+{
+	Text t = "hello";
+	while (t)                       // ERROR: Cannot use 'Text' as a logical condition
+	{
+	}
+}
+
+void test_incompatible_if_literal()
+{
+	if ("yes")                      // ERROR: Cannot use 'Text' as a logical condition
+	{
+	}
+}
+
+void test_incompatible_if_var()
+{
+	Text t = "no";
+	if (t)                          // ERROR: Cannot use 'Text' as a logical condition
+	{
+	}
+}
+
+void test_incompatible_do_while()
+{
+	Integer i = 0;
+	Text msg = "loop";
+	do
+	{
+		i = i + 1;
+	} while (msg);                  // ERROR: Cannot use 'Text' as a logical condition
+}
+
+void test_incompatible_for_condition()
+{
+	Text guard = "x";
+	for (Integer j = 0; guard; j = j + 1) // ERROR: Cannot use 'Text' as a logical condition
+	{
+	}
+}

--- a/scripts/validate-fixtures.ts
+++ b/scripts/validate-fixtures.ts
@@ -34,6 +34,7 @@ import {
 	validateFunctionArguments,
 	validateReturnStatements,
 	validateArraySize,
+	validateLogicalConditions,
 } from '../server/src/core/validators';
 import type { FunctionSignatureMap, OverloadReturnType } from '../server/src/core/validators';
 import type { KnownSymbols, SymbolDeclaration, ParameterSymbolInfo } from '../server/src/core/types';
@@ -487,6 +488,7 @@ function validateFile(filePath: string, prototypes: PrototypeService): Diagnosti
 		pushDiagnostics(validateVoidFunctionReturnValues(result.tree, funcRetTypes));
 		pushDiagnostics(validateReturnStatements(result.tree));
 		pushDiagnostics(validateArraySize(result.tree));
+		pushDiagnostics(validateLogicalConditions(result.tree));
 	}
 
 	return diagnostics;

--- a/server/src/core/validation.LogicalCondition.ts
+++ b/server/src/core/validation.LogicalCondition.ts
@@ -1,0 +1,217 @@
+/**
+ * Logical-condition validation — issue #101.
+ *
+ * Reports when a `while`, `do…while`, `for`, or `if` condition is of a
+ * type that cannot be evaluated as a logical (boolean) expression. The
+ * exemplar is `while ("123")` — a Text literal can never be true/false.
+ *
+ *     while ("123") {}        // Cannot use 'Text' as a logical condition
+ *     if (some_text_var) {}   // Cannot use 'Text' as a logical condition
+ *
+ * Logical-compatible (truthy) types are the numeric types: Integer,
+ * Integer64, Real. Comparison and logical operators always produce a
+ * numeric/boolean result, so any compound expression that uses one is
+ * accepted without further inference. Function-call results and other
+ * expressions whose types cannot be determined are left alone — we
+ * never flag what we cannot prove.
+ */
+
+import {
+	Diagnostic,
+	DiagnosticSeverity,
+} from 'vscode-languageserver/node';
+
+import {
+	safeTokenText,
+	extractIdentifierFromDeclarator,
+} from './validation.Common';
+
+/** Numeric / boolean-compatible 12dPL types. */
+const LOGICAL_COMPATIBLE = new Set([
+	'Integer',
+	'Integer64',
+	'Real',
+	'Logical',
+]);
+
+/** Operator characters that produce a logical/numeric result. */
+const LOGICAL_OPERATOR_RE = /(<|>|<=|>=|==|!=|&&|\|\||!)/;
+
+/**
+ * Try to resolve the type of a simple condition expression. Only
+ * literals and bare identifiers are inferred; compound expressions
+ * (anything containing an operator) return undefined so the caller
+ * can skip them.
+ */
+function resolveSimpleType(text: string, declaredVars: Map<string, string>): string | undefined {
+	if (!text) return undefined;
+
+	if (text.startsWith('"') && text.endsWith('"')) return 'Text';
+	if (/^[0-9]+$/.test(text) || /^0x[0-9a-fA-F]+$/i.test(text)) return 'Integer';
+	if (/^[0-9]*\.[0-9]+$/.test(text)) return 'Real';
+
+	if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(text)) {
+		return declaredVars.get(text);
+	}
+	return undefined;
+}
+
+/** True when the expression text contains a comparison or logical operator. */
+function isCompoundLogicalExpression(text: string): boolean {
+	return LOGICAL_OPERATOR_RE.test(text);
+}
+
+/**
+ * Validates that condition expressions in `if`, `while`, `do…while`,
+ * and `for` loops are of a logical-compatible type.
+ *
+ * @param tree - ANTLR parse tree
+ */
+export function validateLogicalConditions(tree: any): Diagnostic[] {
+	const diagnostics: Diagnostic[] = [];
+
+	let scopedVars = new Map<string, string>();
+
+	const getTypeText = (ctx: any): string | undefined => {
+		try {
+			const text = ctx?.declarationSpecifiers?.()?.getText?.();
+			return typeof text === 'string' && text.length ? text : undefined;
+		} catch { return undefined; }
+	};
+
+	const collectFromDecl = (ctx: any) => {
+		const declType = getTypeText(ctx);
+		if (!declType) return;
+		try {
+			const list = ctx?.initDeclaratorList?.();
+			for (const initDecl of list?.initDeclarator_list?.() ?? []) {
+				const declarator = initDecl?.declarator?.();
+				const info = extractIdentifierFromDeclarator(declarator);
+				if (info) scopedVars.set(info.name, declType);
+			}
+		} catch { /* ignore */ }
+	};
+
+	const reportBadCondition = (
+		exprCtx: any,
+		exprText: string,
+		exprType: string,
+	) => {
+		try {
+			const start = exprCtx?.start;
+			const stop = exprCtx?.stop ?? start;
+			if (!start) return;
+			const startLine = typeof start.line === 'number' ? start.line - 1 : 0;
+			const startCol = typeof start.column === 'number' ? start.column : 0;
+			const endLine = typeof stop?.line === 'number' ? stop.line - 1 : startLine;
+			const stopCol = typeof stop?.column === 'number' ? stop.column : startCol;
+			const stopLen = typeof stop?.text === 'string' ? stop.text.length : 1;
+			diagnostics.push({
+				severity: DiagnosticSeverity.Error,
+				range: {
+					start: { line: startLine, character: startCol },
+					end:   { line: endLine,   character: stopCol + stopLen }
+				},
+				message: `Cannot use '${exprType}' as a logical condition (in '${exprText}')`
+			});
+		} catch { /* ignore */ }
+	};
+
+	const checkConditionExpr = (exprCtx: any) => {
+		if (!exprCtx) return;
+		let exprText = '';
+		try { exprText = exprCtx.getText?.() ?? ''; } catch { /* ignore */ }
+		if (!exprText) return;
+
+		// Compound expressions with a comparison / logical operator always
+		// produce a numeric / boolean result — skip.
+		if (isCompoundLogicalExpression(exprText)) return;
+
+		const type = resolveSimpleType(exprText, scopedVars);
+		if (!type) return;
+		if (LOGICAL_COMPATIBLE.has(type)) return;
+
+		reportBadCondition(exprCtx, exprText, type);
+	};
+
+	const visitor: any = {
+		visitTerminal() { return undefined; },
+		visitErrorNode() { return undefined; },
+		visitChildren(ctx: any) {
+			for (const child of ctx?.children ?? []) {
+				if (child && typeof child.accept === 'function') child.accept(visitor);
+			}
+			return undefined;
+		},
+		visitFunctionDefinition(ctx: any) {
+			const outerVars = scopedVars;
+			scopedVars = new Map<string, string>();
+
+			try {
+				const decl = ctx?.declarator?.();
+				let cur = decl?.directDeclarator?.() ?? decl;
+				while (cur) {
+					const pt = cur.parameterTypeList?.();
+					if (pt) {
+						const plist = pt.parameterList?.();
+						for (const pd of plist?.parameterDeclaration_list?.() ?? []) {
+							const typeText = pd?.declarationSpecifiers?.()?.getText?.();
+							const name = safeTokenText(pd?.Identifier?.());
+							if (name && typeText) scopedVars.set(name, typeText);
+						}
+						break;
+					}
+					cur = cur.directDeclarator?.() ?? null;
+				}
+			} catch { /* ignore */ }
+
+			visitor.visitChildren(ctx);
+
+			scopedVars = outerVars;
+			return undefined;
+		},
+		visitDeclaration(ctx: any) {
+			collectFromDecl(ctx);
+			return visitor.visitChildren(ctx);
+		},
+		visitForDeclaration(ctx: any) {
+			collectFromDecl(ctx);
+			return visitor.visitChildren(ctx);
+		},
+		visitParameterDeclaration(ctx: any) {
+			try {
+				const typeText = ctx?.declarationSpecifiers?.()?.getText?.();
+				const name = safeTokenText(ctx?.Identifier?.());
+				if (name && typeText) scopedVars.set(name, typeText);
+			} catch { /* ignore */ }
+			return visitor.visitChildren(ctx);
+		},
+		visitSelectionStatement(ctx: any) {
+			try {
+				if (ctx?.If?.()) {
+					checkConditionExpr(ctx.expression?.());
+				}
+			} catch { /* ignore */ }
+			return visitor.visitChildren(ctx);
+		},
+		visitIterationStatement(ctx: any) {
+			try {
+				const isWhileOrDo = !!ctx?.While?.();
+				if (isWhileOrDo) {
+					checkConditionExpr(ctx.expression?.());
+				} else if (ctx?.For?.()) {
+					const forCond = ctx.forCondition?.();
+					// Middle expression of `for (init; cond; update)`
+					const innerExprList = forCond?.forExpression_list?.() ?? [];
+					if (innerExprList.length > 0) {
+						checkConditionExpr(innerExprList[0]);
+					}
+				}
+			} catch { /* ignore */ }
+			return visitor.visitChildren(ctx);
+		}
+	};
+
+	try { tree.accept(visitor); } catch { /* ignore */ }
+	return diagnostics;
+}

--- a/server/src/core/validators.ts
+++ b/server/src/core/validators.ts
@@ -22,3 +22,4 @@ export { validateFunctionArguments } from './validation.FunctionArguments';
 export type { FunctionSignatureMap } from './validation.FunctionArguments';
 export { validateArraySize } from './validation.ArraySize';
 export { validateControlFlow } from './validation.ControlFlow';
+export { validateLogicalConditions } from './validation.LogicalCondition';

--- a/server/src/services/diagnosticService.ts
+++ b/server/src/services/diagnosticService.ts
@@ -17,7 +17,8 @@ import { validateVariableRedeclarations,
 	validateFunctionArguments,
 	validateReturnStatements,
 	validateArraySize,
-	validateControlFlow} from '../core/validators';
+	validateControlFlow,
+	validateLogicalConditions} from '../core/validators';
 import type { FunctionSignatureMap, OverloadReturnType } from '../core/validators';
 import type { KnownSymbols, ParameterSymbolInfo } from '../core/types';
 
@@ -103,6 +104,10 @@ export class DiagnosticService {
 			// 3h. Control flow validation (issues #96, #97, #98, #99)
 			const controlFlowDiagnostics = validateControlFlow(parseResult.tree);
 			diagnostics.push(...controlFlowDiagnostics);
+
+			// 3i. Logical condition validation (issue #101)
+			const logicalConditionDiagnostics = validateLogicalConditions(parseResult.tree);
+			diagnostics.push(...logicalConditionDiagnostics);
 		}
 
 		return diagnostics;

--- a/tests/logicalCondition.test.ts
+++ b/tests/logicalCondition.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for logical-condition validation (issue #101).
+ *
+ * Verifies that conditions in `if`, `while`, `do…while`, and `for`
+ * loops are flagged when the expression cannot be evaluated as a
+ * logical (boolean) value, and stay silent for compatible cases.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import * as path from 'path';
+import * as fs from 'fs';
+import { parse } from '../server/src/core/parsePipeline';
+import { validateLogicalConditions } from '../server/src/core/validators';
+
+type Diagnostic = { severity: number; range: any; message: string; [key: string]: any };
+
+const ERROR = 1;
+
+function validate(text: string): Diagnostic[] {
+	const result = parse(text);
+	if (result.syntaxErrors.length > 0) {
+		throw new Error(`Parse errors: ${result.syntaxErrors.map(e => e.message).join(', ')}`);
+	}
+	return validateLogicalConditions(result.tree) as Diagnostic[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #101 — exact reproduction
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('issue #101 reproduction', () => {
+	test('while ("123") flags a single Text-condition error with no %s leak', () => {
+		const diags = validate(`
+void My_function()
+{
+    while ("123")
+    {
+
+    }
+}`);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].severity).toBe(ERROR);
+		expect(diags[0].message).toContain(`'Text'`);
+		expect(diags[0].message).toContain('logical');
+		expect(diags[0].message).not.toContain('%s');
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Compatible conditions — no diagnostics
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('compatible conditions', () => {
+	test('Integer literal in while', () => {
+		expect(validate(`
+void fn() {
+    while (1) { break; }
+}`)).toHaveLength(0);
+	});
+
+	test('Integer variable in while', () => {
+		expect(validate(`
+void fn() {
+    Integer i = 0;
+    while (i) { break; }
+}`)).toHaveLength(0);
+	});
+
+	test('relational expression in while', () => {
+		expect(validate(`
+void fn() {
+    Integer i = 0;
+    while (i < 10) { i = i + 1; }
+}`)).toHaveLength(0);
+	});
+
+	test('equality with strings in if', () => {
+		expect(validate(`
+void fn() {
+    Text t = "hello";
+    if (t == "hello") {}
+}`)).toHaveLength(0);
+	});
+
+	test('Real variable in if', () => {
+		expect(validate(`
+void fn() {
+    Real r = 0.0;
+    if (r) {}
+}`)).toHaveLength(0);
+	});
+
+	test('combined logical in if', () => {
+		expect(validate(`
+void fn() {
+    Integer a = 1;
+    Integer b = 2;
+    if (a > 0 && b < 3) {}
+}`)).toHaveLength(0);
+	});
+
+	test('for with relational condition', () => {
+		expect(validate(`
+void fn() {
+    for (Integer j = 0; j < 10; j = j + 1) {}
+}`)).toHaveLength(0);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Incompatible conditions
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('incompatible conditions', () => {
+	test('Text literal in while', () => {
+		const diags = validate(`
+void fn() {
+    while ("x") {}
+}`);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain(`'Text'`);
+	});
+
+	test('Text variable in while', () => {
+		const diags = validate(`
+void fn() {
+    Text t = "hello";
+    while (t) {}
+}`);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain(`'Text'`);
+	});
+
+	test('Text literal in if', () => {
+		const diags = validate(`
+void fn() {
+    if ("yes") {}
+}`);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain(`'Text'`);
+	});
+
+	test('Text variable in if', () => {
+		const diags = validate(`
+void fn() {
+    Text t = "no";
+    if (t) {}
+}`);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain(`'Text'`);
+	});
+
+	test('Text variable in do…while', () => {
+		const diags = validate(`
+void fn() {
+    Integer i = 0;
+    Text msg = "loop";
+    do {
+        i = i + 1;
+    } while (msg);
+}`);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain(`'Text'`);
+	});
+
+	test('Text variable as for-condition', () => {
+		const diags = validate(`
+void fn() {
+    Text guard = "x";
+    for (Integer j = 0; guard; j = j + 1) {}
+}`);
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain(`'Text'`);
+	});
+
+	test('every diagnostic is an ERROR with no leaked %s', () => {
+		const diags = validate(`
+void fn() {
+    Text a = "x";
+    Text b = "y";
+    if (a) {}
+    while (b) {}
+}`);
+		expect(diags).toHaveLength(2);
+		for (const d of diags) {
+			expect(d.severity).toBe(ERROR);
+			expect(d.message).not.toContain('%s');
+		}
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Scope isolation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('scope isolation', () => {
+	test('identical names in different functions resolve independently', () => {
+		const diags = validate(`
+void a()
+{
+    Text x = "t";
+    if (x) {}
+}
+
+void b()
+{
+    Integer x = 0;
+    if (x) {}
+}`);
+		// Only function a()'s Text condition should be flagged
+		expect(diags).toHaveLength(1);
+		expect(diags[0].message).toContain(`'Text'`);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Full fixture sanity check
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('client/testFixture/logical_condition.4dm fixture', () => {
+	test('produces exactly the expected ERROR diagnostics', () => {
+		const fixturePath = path.resolve(__dirname, '..', 'client', 'testFixture', 'logical_condition.4dm');
+		const text = fs.readFileSync(fixturePath, 'utf-8');
+		const diags = validate(text);
+
+		for (const d of diags) {
+			expect(d.severity).toBe(ERROR);
+			expect(d.message).toContain('logical');
+			expect(d.message).not.toContain('%s');
+		}
+
+		// 6 incompatible-condition functions in the fixture, each with one error
+		expect(diags).toHaveLength(6);
+	});
+});


### PR DESCRIPTION
## Summary
- Adds `validateLogicalConditions` covering `if`, `while`, `do…while`, and `for` test expressions.
- Reports `Cannot use '<type>' as a logical condition (in '<expr>')` when the condition is a literal or bare identifier whose type is not `Integer`, `Integer64`, `Real`, or `Logical`.
- Compound expressions containing comparison or logical operators (`<`, `==`, `&&`, etc.) are accepted unconditionally — they always produce a numeric/boolean result.
- Wires the validator into `DiagnosticService` and the offline `validate-fixtures` script.

Closes #101
Closes #102

(#102 is the `if ("123")` variant of the same bug as #101's `while ("123")` — the new validator handles `if`, `while`, `do…while`, and `for` uniformly, so both are fixed.)

## Test plan
- [x] 17 new unit tests in `tests/logicalCondition.test.ts` (issue-#101 reproduction, all four loop/conditional kinds, compatible cases, scope isolation, fixture shape — asserts no `%s` ever appears).
- [x] New `.4dm` fixture `client/testFixture/logical_condition.4dm` with 6 expected errors and compatible-case coverage.
- [x] Full suite: `bun test` — 316 pass / 0 fail.
- [x] `bun run scripts/validate-fixtures.ts fixtures --filter logical_condition` reports the 6 expected errors.
- [x] Verified the exact issue-#102 example (`if ("123");`) produces `Cannot use 'Text' as a logical condition (in '"123"')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)