### PR TITLE
Updated fortmatting provider to add new functionality.

### DIFF
--- a/client/src/formattingFeature.ts
+++ b/client/src/formattingFeature.ts
@@ -14,12 +14,27 @@ export function registerFormattingFeatures(context: ExtensionContext) {
             }
 
             const indentSize = Number(config.get<number>('indentSize', 4));
+            const preserveBlankLines = Boolean(config.get<boolean>('formatter.preserveBlankLines', false));
+            const bracketStyle = config.get<string>('formatter.bracketStyle', 'preserve') as 'preserve' | 'same-line' | 'new-line';
+            const maxLineLength = Number(config.get<number>('formatter.maxLineLength', 0));
+            const indentStyle = config.get<string>('formatter.indentStyle', 'editor') as 'editor' | 'spaces' | 'tabs';
             const editorConfig = workspace.getConfiguration('editor', event.document.uri);
-            const insertSpaces = Boolean(editorConfig.get<boolean>('insertSpaces', true));
+            // indentStyle overrides editor.insertSpaces when explicitly set to 'spaces' or 'tabs'.
+            const editorInsertSpaces = Boolean(editorConfig.get<boolean>('insertSpaces', true));
+            const insertSpaces = indentStyle === 'spaces' ? true
+                : indentStyle === 'tabs' ? false
+                : editorInsertSpaces;
+            // Prefer 12dpl.indentSize; fall back to editor.tabSize so language-specific
+            // tab size overrides (e.g. "[12dpl]": { "editor.tabSize": 2 }) are respected.
+            const editorTabSize = Number(editorConfig.get<number>('tabSize', 4));
+            const resolvedTabSize = Number.isFinite(indentSize) && indentSize > 0 ? indentSize : editorTabSize;
 
             const options = {
-                tabSize: Number.isFinite(indentSize) && indentSize > 0 ? indentSize : 4,
-                insertSpaces
+                tabSize: resolvedTabSize,
+                insertSpaces,
+                preserveBlankLines,
+                bracketStyle,
+                maxLineLength: Number.isFinite(maxLineLength) && maxLineLength > 0 ? maxLineLength : 0
             };
 
             event.waitUntil(

--- a/client/testFixture/formatting.4dm
+++ b/client/testFixture/formatting.4dm
@@ -1,0 +1,22 @@
+/*
+    This is an example file to test the formatting of 4dm files. It should be formatted according to the rules specified 
+                in the documentation.
+ */
+
+Integer my_func(Integer a, Integer b)
+{
+	return a + b;
+}
+
+void very_long_function_name_with_many_parameters(
+Integer param1, Integer param2, Integer param3, Integer param4, Integer param5, Integer param6,
+Integer param7, Integer param8, Integer param9, Integer param10)
+{
+}
+
+// this is a comment that should be properly formatted and aligned with the code. It should not affect the functionality of the code, but it should be easy to read and understand.
+void main()
+{
+	Integer result = my_func(5, 10);
+		
+}

--- a/package.json
+++ b/package.json
@@ -192,7 +192,43 @@
 					"scope": "resource",
 					"type": "number",
 					"default": 4,
-					"description": "Indent size (spaces) used by the 12dPL formatter."
+					"description": "Number of spaces per indent level used by the 12dPL formatter (also controls how many spaces a tab counts as when indentStyle is 'spaces')."
+				},
+				"12dpl.formatter.indentStyle": {
+					"scope": "resource",
+					"type": "string",
+					"default": "editor",
+					"enum": ["editor", "spaces", "tabs"],
+					"enumDescriptions": [
+						"Use the editor.insertSpaces setting to decide (default).",
+						"Always indent with spaces, replacing any existing tab indentation.",
+						"Always indent with tabs, replacing any existing space indentation."
+					],
+					"description": "Controls whether the formatter uses spaces or tabs for indentation, overriding the editor.insertSpaces setting. 'editor' defers to VS Code's setting."
+				},
+				"12dpl.formatter.preserveBlankLines": {
+					"scope": "resource",
+					"type": "boolean",
+					"default": false,
+					"description": "When enabled, blank lines keep their original whitespace during formatting. This prevents format-on-save from moving the cursor to column 0 when it is positioned on a blank line."
+				},
+				"12dpl.formatter.bracketStyle": {
+					"scope": "resource",
+					"type": "string",
+					"default": "preserve",
+					"enum": ["preserve", "same-line", "new-line"],
+					"enumDescriptions": [
+						"Do not modify brace positions (default).",
+						"Place opening braces at the end of the preceding statement line (K&R style).",
+						"Place opening braces on their own line (Allman style)."
+					],
+					"description": "Controls where opening braces are placed during formatting. 'preserve' leaves braces unchanged; 'same-line' moves lone opening braces up to the previous line (K&R); 'new-line' moves trailing opening braces onto their own line (Allman)."
+				},
+				"12dpl.formatter.maxLineLength": {
+					"scope": "resource",
+					"type": "number",
+					"default": 100,
+					"description": "Maximum line length before the formatter inserts a line break at the nearest safe point (after a comma or logical operator). Set to 0 to disable (default)."
 				},
 				"langServer.maxNumberOfProblems": {
 					"scope": "resource",

--- a/server/src/providers/formattingProvider.ts
+++ b/server/src/providers/formattingProvider.ts
@@ -13,11 +13,48 @@ export function registerFormattingProvider(opts: {
 }): void {
 	const { connection, documents } = opts;
 
-	connection.onDocumentFormatting((params: DocumentFormattingParams) => {
+	connection.onDocumentFormatting(async (params: DocumentFormattingParams) => {
 		const document = documents.get(params.textDocument.uri);
 		if (!document) return [];
 
-		const formatted = format12dplDocument(document.getText(), params.options);
+		let preserveBlankLines = false;
+		let bracketStyle: 'preserve' | 'same-line' | 'new-line' = 'preserve';
+		let maxLineLength = 0;
+		let indentStyle: 'editor' | 'spaces' | 'tabs' = 'editor';
+		try {
+			const cfg = await connection.workspace.getConfiguration({
+				scopeUri: params.textDocument.uri,
+				section: '12dpl'
+			});
+			preserveBlankLines = !!(cfg?.formatter?.preserveBlankLines);
+			const rawStyle = cfg?.formatter?.bracketStyle;
+			if (rawStyle === 'same-line' || rawStyle === 'new-line') {
+				bracketStyle = rawStyle;
+			}
+			const rawMax = cfg?.formatter?.maxLineLength;
+			if (typeof rawMax === 'number' && rawMax > 0) {
+				maxLineLength = rawMax;
+			}
+			const rawIndent = cfg?.formatter?.indentStyle;
+			if (rawIndent === 'spaces' || rawIndent === 'tabs') {
+				indentStyle = rawIndent;
+			}
+		} catch {
+			// ignore — fall back to defaults
+		}
+
+		// indentStyle overrides whatever VS Code passed in params.options.insertSpaces
+		const insertSpaces = indentStyle === 'spaces' ? true
+			: indentStyle === 'tabs' ? false
+			: params.options.insertSpaces;
+
+		const formatted = format12dplDocument(document.getText(), {
+			...params.options,
+			insertSpaces,
+			preserveBlankLines,
+			bracketStyle,
+			maxLineLength
+		});
 		const fullRange = {
 			start: document.positionAt(0),
 			end: document.positionAt(document.getText().length)

--- a/server/src/services/formattingService.ts
+++ b/server/src/services/formattingService.ts
@@ -1,5 +1,14 @@
 import type { FormattingOptions } from 'vscode-languageserver/node';
 
+export interface Format12dplOptions extends FormattingOptions {
+	/** When true, blank lines keep their original whitespace rather than being stripped to empty. */
+	preserveBlankLines?: boolean;
+	/** Where to place opening braces. Default 'preserve' leaves them unchanged. */
+	bracketStyle?: 'preserve' | 'same-line' | 'new-line';
+	/** When > 0, lines longer than this are broken at the nearest safe point (comma, &&, ||). 0 = disabled. */
+	maxLineLength?: number;
+}
+
 /** Counts how many times `charToCount` repeats from the start of `text`. */
 function countLeadingChar(text: string, charToCount: string): number {
 	let count = 0;
@@ -96,11 +105,162 @@ function scanBraces(line: string, state: ScanState): { opens: number; closes: nu
 }
 
 /**
+ * K&R post-pass: if a line is only `{`, merge it (with ` {`) onto the previous
+ * non-blank line, removing any blank lines that sit between them.
+ */
+function applyKnRStyle(lines: string[]): string[] {
+	const result: string[] = [];
+	for (const line of lines) {
+		if (line.trim() === '{') {
+			let prevIdx = result.length - 1;
+			while (prevIdx >= 0 && result[prevIdx].trim() === '') {
+				prevIdx--;
+			}
+			if (prevIdx >= 0) {
+				// Remove any blank lines that were between prevIdx and here
+				result.splice(prevIdx + 1);
+				result[prevIdx] = result[prevIdx] + ' {';
+				continue;
+			}
+		}
+		result.push(line);
+	}
+	return result;
+}
+
+/**
+ * Allman post-pass: if a line ends with an unquoted `{` that has real code before it,
+ * split it so the `{` sits on its own line with the same indentation.
+ * Respects strings, line comments, and block comments.
+ */
+function applyAllmanStyle(lines: string[]): string[] {
+	const result: string[] = [];
+	// Track block-comment state across lines using the existing ScanState machinery.
+	const state: ScanState = { inBlockComment: false, inString: false, stringQuote: null };
+
+	for (const line of lines) {
+		const wasInBlockComment = state.inBlockComment;
+		// Advance state but discard brace counts — we only need the block-comment update.
+		scanBraces(line, state);
+
+		if (wasInBlockComment) {
+			result.push(line);
+			continue;
+		}
+
+		// Find the last unquoted `{` in the code portion of this line.
+		let inStr = false;
+		let strQ: '"' | "'" | null = null;
+		let lastCodeBraceIdx = -1;
+		let codeEnd = line.length; // index where the "code" ends (before any line comment)
+		let i = 0;
+
+		while (i < line.length) {
+			const ch = line[i];
+			const next = i + 1 < line.length ? line[i + 1] : '';
+
+			if (inStr) {
+				if (ch === '\\') { i += 2; continue; }
+				if (ch === strQ) { inStr = false; strQ = null; }
+				i++;
+				continue;
+			}
+
+			if (ch === '/' && next === '/') { codeEnd = i; break; }
+			if (ch === '"' || ch === "'") { inStr = true; strQ = ch as '"' | "'"; i++; continue; }
+			if (ch === '{') lastCodeBraceIdx = i;
+			i++;
+		}
+
+		if (lastCodeBraceIdx < 0) {
+			result.push(line);
+			continue;
+		}
+
+		// Confirm the `{` is the last code token (nothing after it but whitespace / comment)
+		const afterBrace = line.slice(lastCodeBraceIdx + 1, codeEnd).trim();
+		const beforeBrace = line.slice(0, lastCodeBraceIdx).trim();
+
+		if (afterBrace !== '' || beforeBrace === '' || line.trimStart().startsWith('#')) {
+			result.push(line);
+			continue;
+		}
+
+		// Split: content before brace, then brace on its own line with same indent.
+		const indent = line.slice(0, line.length - line.trimStart().length);
+		const before = line.slice(0, lastCodeBraceIdx).trimEnd();
+		result.push(before);
+		result.push(indent + '{');
+	}
+
+	return result;
+}
+
+/**
+ * Wraps a single line that exceeds `maxLen` at the rightmost safe break point
+ * before the limit (comma > logical operator). Returns one or more lines.
+ * Recursively wraps the continuation if it is still too long.
+ */
+function wrapLine(line: string, maxLen: number, options: Format12dplOptions): string[] {
+	if (line.length <= maxLen) return [line];
+
+	const lineIndent = /^(\s*)/.exec(line)?.[1] ?? '';
+	const contIndent = lineIndent + makeIndent(1, options);
+
+	let bestBreak = -1;
+	let inStr = false;
+	let strQ: '"' | "'" | null = null;
+
+	for (let i = 0; i < maxLen && i < line.length; i++) {
+		const ch = line[i];
+		const next = i + 1 < line.length ? line[i + 1] : '';
+
+		if (inStr) {
+			if (ch === '\\') { i++; continue; }
+			if (ch === strQ) { inStr = false; strQ = null; }
+			continue;
+		}
+
+		// Do not break inside or after line comments.
+		if (ch === '/' && next === '/') break;
+
+		if (ch === '"' || ch === "'") { inStr = true; strQ = ch as '"' | "'"; continue; }
+
+		// Safe break positions (later position wins, giving rightmost break before limit).
+		if (ch === ',') { bestBreak = i + 1; continue; }
+		if (ch === '&' && next === '&') { bestBreak = i + 2; continue; }
+		if (ch === '|' && next === '|') { bestBreak = i + 2; continue; }
+	}
+
+	if (bestBreak < 0 || bestBreak >= line.length - 1) {
+		return [line]; // no safe break found before the limit
+	}
+
+	const before = line.slice(0, bestBreak);
+	const remaining = contIndent + line.slice(bestBreak).trimStart();
+
+	return [before, ...wrapLine(remaining, maxLen, options)];
+}
+
+/** Applies max-line-length wrapping to all lines; skips blank and preprocessor lines. */
+function applyMaxLineLength(lines: string[], maxLen: number, options: Format12dplOptions): string[] {
+	const result: string[] = [];
+	for (const line of lines) {
+		if (line.length <= maxLen || line.trim() === '' || line.trimStart().startsWith('#')) {
+			result.push(line);
+		} else {
+			result.push(...wrapLine(line, maxLen, options));
+		}
+	}
+	return result;
+}
+
+/**
  * Formats a full 12dPL document using simple brace-based indentation.
  *
  * Intended to be deterministic and safe (best-effort) rather than stylistically perfect.
  */
-export function format12dplDocument(text: string, options: FormattingOptions): string {
+export function format12dplDocument(text: string, options: Format12dplOptions): string {
 	// Preserve original newline style.
 	const newline = text.includes('\r\n') ? '\r\n' : '\n';
 	const lines = text.split(/\r?\n/);
@@ -114,7 +274,7 @@ export function format12dplDocument(text: string, options: FormattingOptions): s
 		const trimmed = originalLine.trim();
 
 		if (trimmed.length === 0) {
-			formatted.push('');
+			formatted.push(options.preserveBlankLines ? originalLine : '');
 			continue;
 		}
 
@@ -124,6 +284,10 @@ export function format12dplDocument(text: string, options: FormattingOptions): s
 			continue;
 		}
 
+		// Snapshot block-comment state before scanning — true if this line started
+		// inside a /* ... */ block comment opened on a prior line.
+		const wasInBlockComment = state.inBlockComment;
+
 		// Compute indentation for the current line. Reduce indent for leading closing braces.
 		const leadingCloseCount = countLeadingChar(trimmed, '}');
 		let lineIndentLevel = indentLevel - leadingCloseCount;
@@ -131,7 +295,12 @@ export function format12dplDocument(text: string, options: FormattingOptions): s
 			lineIndentLevel = Math.max(0, lineIndentLevel - 1);
 		}
 
-		formatted.push(`${makeIndent(lineIndentLevel, options)}${trimmed}`);
+		if (wasInBlockComment) {
+			// Preserve original content — block comment interior lines are not reindented.
+			formatted.push(originalLine);
+		} else {
+			formatted.push(`${makeIndent(lineIndentLevel, options)}${trimmed}`);
+		}
 
 		const { opens, closes } = scanBraces(originalLine, state);
 		indentLevel += opens - closes;
@@ -140,5 +309,22 @@ export function format12dplDocument(text: string, options: FormattingOptions): s
 		}
 	}
 
-	return formatted.join(newline);
+	// Apply brace-style post-pass if requested.
+	const style = options.bracketStyle ?? 'preserve';
+	let postFormatted: string[];
+	if (style === 'same-line') {
+		postFormatted = applyKnRStyle(formatted);
+	} else if (style === 'new-line') {
+		postFormatted = applyAllmanStyle(formatted);
+	} else {
+		postFormatted = formatted;
+	}
+
+	// Apply max line length wrapping if configured.
+	const maxLen = options.maxLineLength ?? 0;
+	if (maxLen > 0) {
+		postFormatted = applyMaxLineLength(postFormatted, maxLen, options);
+	}
+
+	return postFormatted.join(newline);
 }

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -24,4 +24,307 @@ describe("format12dplDocument", () => {
 		expect(lines[0]).toBe("#if DEBUG");
 		expect(lines[4]).toBe("#endif");
 	});
+
+	test("strips blank line whitespace by default", () => {
+		const input = "void main() {\n    \n}\n";
+		const formatted = format12dplDocument(input, { insertSpaces: true, tabSize: 4 });
+		const lines = formatted.split("\n");
+		// blank line should be empty
+		expect(lines[1]).toBe("");
+	});
+
+	test("preserveBlankLines: keeps original whitespace on blank lines", () => {
+		const input = "void main() {\n    \n}\n";
+		const formatted = format12dplDocument(input, {
+			insertSpaces: true,
+			tabSize: 4,
+			preserveBlankLines: true
+		});
+		const lines = formatted.split("\n");
+		// blank line should keep its original whitespace intact
+		expect(lines[1]).toBe("    ");
+	});
+
+	test("preserveBlankLines: truly empty blank lines remain empty", () => {
+		const input = "void main() {\n\n}\n";
+		const formatted = format12dplDocument(input, {
+			insertSpaces: true,
+			tabSize: 4,
+			preserveBlankLines: true
+		});
+		const lines = formatted.split("\n");
+		expect(lines[1]).toBe("");
+	});
+
+	test("preserveBlankLines: non-blank lines still get correct indentation", () => {
+		const input = "void main() {\n    \nInteger x = 1;\n}\n";
+		const formatted = format12dplDocument(input, {
+			insertSpaces: true,
+			tabSize: 4,
+			preserveBlankLines: true
+		});
+		const lines = formatted.split("\n");
+		expect(lines[0]).toBe("void main() {");
+		expect(lines[1]).toBe("    "); // blank line preserved as-is
+		expect(lines[2]).toBe("    Integer x = 1;"); // non-blank still indented
+		expect(lines[3]).toBe("}");
+	});
+});
+
+describe("format12dplDocument — bracketStyle", () => {
+	const base = { insertSpaces: true, tabSize: 4 };
+
+	// ── same-line (K&R) ──────────────────────────────────────────────────────
+
+	test("same-line: merges lone { onto previous line", () => {
+		const input = "void main()\n{\n    Integer x = 1;\n}\n";
+		const lines = format12dplDocument(input, { ...base, bracketStyle: 'same-line' }).split("\n");
+		expect(lines[0]).toBe("void main() {");
+		expect(lines[1]).toBe("    Integer x = 1;");
+		expect(lines[2]).toBe("}");
+	});
+
+	test("same-line: absorbs blank lines between statement and lone {", () => {
+		const input = "void foo()\n\n{\n    Integer x;\n}\n";
+		const lines = format12dplDocument(input, { ...base, bracketStyle: 'same-line' }).split("\n");
+		expect(lines[0]).toBe("void foo() {");
+		expect(lines[1]).toBe("    Integer x;");
+	});
+
+	test("same-line: does not change a brace already on the same line", () => {
+		const input = "void main() {\n    Integer x = 1;\n}\n";
+		const lines = format12dplDocument(input, { ...base, bracketStyle: 'same-line' }).split("\n");
+		expect(lines[0]).toBe("void main() {");
+	});
+
+	test("same-line: handles nested blocks", () => {
+		const input = "void main()\n{\n    if (x)\n    {\n        Integer y;\n    }\n}\n";
+		const out = format12dplDocument(input, { ...base, bracketStyle: 'same-line' });
+		const lines = out.split("\n");
+		expect(lines[0]).toBe("void main() {");
+		expect(lines[1]).toBe("    if (x) {");
+		expect(lines[2]).toBe("        Integer y;");
+	});
+
+	// ── new-line (Allman) ─────────────────────────────────────────────────────
+
+	test("new-line: splits trailing { onto its own line", () => {
+		const input = "void main() {\n    Integer x = 1;\n}\n";
+		const lines = format12dplDocument(input, { ...base, bracketStyle: 'new-line' }).split("\n");
+		expect(lines[0]).toBe("void main()");
+		expect(lines[1]).toBe("{");
+		expect(lines[2]).toBe("    Integer x = 1;");
+		expect(lines[3]).toBe("}");
+	});
+
+	test("new-line: splits } else { correctly", () => {
+		const input = "void main() {\n    if (x) {\n        Integer a;\n    } else {\n        Integer b;\n    }\n}\n";
+		const out = format12dplDocument(input, { ...base, bracketStyle: 'new-line' });
+		// } else { is indented at level 1, so the split produces "    } else" and "    {"
+		expect(out).toContain("} else\n    {");
+	});
+
+	test("new-line: does not split a lone { line", () => {
+		// Starting from Allman input — lone { should remain lone {
+		const input = "void main()\n{\n    Integer x;\n}\n";
+		const lines = format12dplDocument(input, { ...base, bracketStyle: 'new-line' }).split("\n");
+		// After indentation pass lone { stays. No further splitting of lone {.
+		expect(lines[0]).toBe("void main()");
+		expect(lines[1]).toBe("{");
+	});
+
+	test("new-line: does not split { inside a string", () => {
+		const input = 'void main() {\n    Text x = "{";\n}\n';
+		const out = format12dplDocument(input, { ...base, bracketStyle: 'new-line' });
+		// The string line should not be touched by Allman splitting
+		expect(out).toContain('Text x = "{";');
+	});
+
+	test("new-line: does not split { inside a line comment", () => {
+		const input = "void main() {\n    Integer x = 1; // value {\n}\n";
+		const lines = format12dplDocument(input, { ...base, bracketStyle: 'new-line' }).split("\n");
+		// "    Integer x = 1; // value {" ends with { in comment — should not split
+		const commentLine = lines.find(l => l.includes("// value {"));
+		expect(commentLine).toBeDefined();
+	});
+
+	test("new-line: does not split preprocessor directives", () => {
+		// #if lines are already kept hard-left; Allman should not attempt to split them
+		const input = "#if DEBUG\nvoid foo() {\n    Integer x;\n}\n#endif\n";
+		const out = format12dplDocument(input, { ...base, bracketStyle: 'new-line' });
+		expect(out).toContain("#if DEBUG");
+		// The { after void foo() should split
+		expect(out).toContain("void foo()\n{");
+	});
+
+	// ── preserve (default) ────────────────────────────────────────────────────
+
+	test("preserve: does not reposition braces", () => {
+		const input = "void main() {\n    Integer x = 1;\n}\n";
+		const out = format12dplDocument(input, { ...base, bracketStyle: 'preserve' });
+		expect(out.split("\n")[0]).toBe("void main() {");
+	});
+});
+
+describe("format12dplDocument — block comment preservation (#104)", () => {
+	const base = { insertSpaces: true, tabSize: 4 };
+
+	test("lines inside block comment are kept as-is (not reindented)", () => {
+		//   The comment body has unusual indentation — the formatter must not touch it.
+		const input = "void main() {\n/*\n * This is a block comment\n *   with odd indentation\n */\n    Integer x = 1;\n}\n";
+		const out = format12dplDocument(input, base);
+		expect(out).toContain(" * This is a block comment");
+		expect(out).toContain(" *   with odd indentation");
+		expect(out).toContain(" */");
+	});
+
+	test("the line that opens /* is still indented normally", () => {
+		const input = "void main() {\n/* starts here */\n    Integer x = 1;\n}\n";
+		const out = format12dplDocument(input, base);
+		const lines = out.split("\n");
+		// The /* line starts the comment but was not already inside one — format normally
+		expect(lines[1]).toBe("    /* starts here */");
+	});
+
+	test("single-line /* */ comment is indented normally", () => {
+		const input = "void main() {\n/* one liner */\nInteger x = 1;\n}\n";
+		const out = format12dplDocument(input, base);
+		const lines = out.split("\n");
+		expect(lines[1]).toBe("    /* one liner */");
+		expect(lines[2]).toBe("    Integer x = 1;");
+	});
+
+	test("code after closing */ is indented normally", () => {
+		const input = "void main() {\n/*\n * comment\n */\nInteger x = 1;\n}\n";
+		const out = format12dplDocument(input, base);
+		// The line with */ is inside the comment (preserved), but the next code line is normal
+		expect(out).toContain("    Integer x = 1;");
+	});
+
+	test("block comment inside nested block still preserved", () => {
+		const input = "void main() {\n    if (x) {\n/*\n * nested comment\n */\n        Integer y;\n    }\n}\n";
+		const out = format12dplDocument(input, base);
+		expect(out).toContain(" * nested comment");
+		expect(out).toContain("        Integer y;");
+	});
+});
+
+describe("format12dplDocument — maxLineLength", () => {
+	const base = { insertSpaces: true, tabSize: 4 };
+
+	test("lines at or below the limit are unchanged", () => {
+		const input = "void main() {\n    Integer x = 1;\n}\n";
+		const out = format12dplDocument(input, { ...base, maxLineLength: 80 });
+		expect(out).toBe(format12dplDocument(input, base));
+	});
+
+	test("wraps at rightmost comma before the limit", () => {
+		// Line: "    Integer result = someFunc(paramOne, paramTwo, paramThree);" (62 chars)
+		const input = "void main() {\n    Integer result = someFunc(paramOne, paramTwo, paramThree);\n}\n";
+		const out = format12dplDocument(input, { ...base, maxLineLength: 55 });
+		const lines = out.split("\n");
+		// Should break after the last comma that fits within 55 chars
+		expect(lines.some(l => l.trimEnd().endsWith(","))).toBe(true);
+		// No line should exceed the limit
+		expect(lines.every(l => l.length <= 55)).toBe(true);
+	});
+
+	test("wraps at && before the limit", () => {
+		const input = "void main() {\n    if (conditionOne && conditionTwo && conditionThree) {\n    }\n}\n";
+		const out = format12dplDocument(input, { ...base, maxLineLength: 40 });
+		const lines = out.split("\n");
+		expect(lines.every(l => l.length <= 40)).toBe(true);
+	});
+
+	test("wraps at || before the limit", () => {
+		const input = "void main() {\n    if (firstCondition || secondCondition || thirdCondition) {\n    }\n}\n";
+		const out = format12dplDocument(input, { ...base, maxLineLength: 40 });
+		const lines = out.split("\n");
+		expect(lines.every(l => l.length <= 40)).toBe(true);
+	});
+
+	test("leaves line unchanged when no safe break exists before limit", () => {
+		// A very long identifier with no break points
+		const input = "void main() {\n    Integer averylongvariablenamethathasnosafebreakpoint = 0;\n}\n";
+		const out = format12dplDocument(input, { ...base, maxLineLength: 20 });
+		// The offending line cannot be broken — it must be output as-is
+		expect(out).toContain("averylongvariablenamethathasnosafebreakpoint");
+	});
+
+	test("does not break inside a string", () => {
+		const input = 'void main() {\n    Text x = "a very long string, with a comma inside it that is long";\n}\n';
+		const out = format12dplDocument(input, { ...base, maxLineLength: 40 });
+		// The comma inside the string must not be used as a break point
+		expect(out).toContain('"a very long string, with a comma inside it that is long"');
+	});
+
+	test("does not wrap preprocessor directives", () => {
+		const input = "#define VERY_LONG_MACRO_NAME(a, b, c) ((a) + (b) + (c))\nvoid main() {\n}\n";
+		const out = format12dplDocument(input, { ...base, maxLineLength: 20 });
+		expect(out).toContain("#define VERY_LONG_MACRO_NAME(a, b, c) ((a) + (b) + (c))");
+	});
+
+	test("applies recursively for very long lines", () => {
+		// Force multiple wraps
+		const input = "void main() {\n    Integer x = func(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p);\n}\n";
+		const out = format12dplDocument(input, { ...base, maxLineLength: 30 });
+		const lines = out.split("\n");
+		expect(lines.every(l => l.length <= 30)).toBe(true);
+	});
+
+	test("maxLineLength 0 disables wrapping", () => {
+		const input = "void main() {\n    Integer result = someFunc(paramOne, paramTwo, paramThree, paramFour, paramFive);\n}\n";
+		const out = format12dplDocument(input, { ...base, maxLineLength: 0 });
+		// No line breaks inserted — long line stays intact
+		expect(out).toContain("someFunc(paramOne, paramTwo, paramThree, paramFour, paramFive)");
+	});
+});
+
+describe("format12dplDocument — indentStyle (spaces vs tabs)", () => {
+	test("insertSpaces: true converts tab-indented file to spaces", () => {
+		// Input uses tab indentation
+		const input = "void main() {\n\tInteger x = 1;\n\tInteger y = 2;\n}\n";
+		const out = format12dplDocument(input, { insertSpaces: true, tabSize: 4 });
+		const lines = out.split("\n");
+		expect(lines[1]).toBe("    Integer x = 1;");
+		expect(lines[2]).toBe("    Integer y = 2;");
+		// No tabs remain in the output
+		expect(out).not.toContain("\t");
+	});
+
+	test("insertSpaces: false converts space-indented file to tabs", () => {
+		// Input uses space indentation
+		const input = "void main() {\n    Integer x = 1;\n    Integer y = 2;\n}\n";
+		const out = format12dplDocument(input, { insertSpaces: false, tabSize: 4 });
+		const lines = out.split("\n");
+		expect(lines[1]).toBe("\tInteger x = 1;");
+		expect(lines[2]).toBe("\tInteger y = 2;");
+		// No leading spaces remain (the tab replaces them all)
+		expect(lines[1].startsWith(" ")).toBe(false);
+	});
+
+	test("insertSpaces: true uses tabSize to control space count per level", () => {
+		const input = "void main() {\nif (x) {\nInteger y = 1;\n}\n}\n";
+		const out2 = format12dplDocument(input, { insertSpaces: true, tabSize: 2 });
+		const out4 = format12dplDocument(input, { insertSpaces: true, tabSize: 4 });
+		expect(out2.split("\n")[1]).toBe("  if (x) {");
+		expect(out4.split("\n")[1]).toBe("    if (x) {");
+	});
+
+	test("insertSpaces: false produces single tab per indent level regardless of tabSize", () => {
+		const input = "void main() {\nif (x) {\nInteger y;\n}\n}\n";
+		const out = format12dplDocument(input, { insertSpaces: false, tabSize: 4 });
+		const lines = out.split("\n");
+		// Nested line should have two tabs
+		expect(lines[2]).toBe("\t\tInteger y;");
+	});
+
+	test("mixed indentation in input is normalised to the chosen style", () => {
+		// First block uses tabs, second uses spaces — should both come out as spaces
+		const input = "void a() {\n\tInteger x;\n}\nvoid b() {\n    Integer y;\n}\n";
+		const out = format12dplDocument(input, { insertSpaces: true, tabSize: 4 });
+		expect(out).not.toContain("\t");
+		expect(out).toContain("    Integer x;");
+		expect(out).toContain("    Integer y;");
+	});
 });


### PR DESCRIPTION
- Tab indentation
- No formatting of the line the cursor is currently on (could be blank, currently removes all whitespace on that line)
- Change function bracket style (new line vs end of function definition)
- Max line length - inserts new line at closest break
- Ignores block comments

This should close #92 and #104 