### PR TITLE
Fixed multiple bracket pairs in pre proc macros causing invalid syntax errors

### DIFF
--- a/client/testFixture/macro_defines.4dm
+++ b/client/testFixture/macro_defines.4dm
@@ -1,14 +1,14 @@
 
-void someOtherfunction()
+Integer someOtherfunction()
 {
-
+	return 1;
 }
  
 void func()
 {
-    #define MACRO_EXAMPLE Integer test = 1;
+    #define MACRO_EXAMPLE(x,y) Integer test = &x;
 
-    MACRO_EXAMPLE
+    MACRO_EXAMPLE(someOtherfunction() + someOtherfunction(), someOtherfunction())
 
     someOtherfunction();
 }

--- a/server/src/core/parsePipeline.ts
+++ b/server/src/core/parsePipeline.ts
@@ -319,14 +319,49 @@ export function stripStandaloneMacroUsages(strippedText: string, rawText: string
 	}
 	if (defineNames.size === 0) return strippedText;
 
-	// Replace lines that are ONLY a macro name (with optional args) and no trailing semicolon
+	// Replace lines that are ONLY a macro name (with optional args) and no trailing semicolon.
+	// Walks balanced parentheses so nested calls like MACRO(foo()) are handled correctly.
 	const lines = strippedText.split('\n');
 	for (let i = 0; i < lines.length; i++) {
 		const trimmed = lines[i].trim();
 		if (!trimmed) continue;
-		// Matches: IDENTIFIER or IDENTIFIER(anything) with no trailing semicolon
-		const usageMatch = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)(\([^)]*\))?\s*$/);
-		if (usageMatch && defineNames.has(usageMatch[1])) {
+
+		const identMatch = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)/);
+		if (!identMatch || !defineNames.has(identMatch[1])) continue;
+
+		const rest = trimmed.slice(identMatch[1].length).trimStart();
+
+		// No arguments — bare macro identifier with nothing after it
+		if (rest === '') {
+			lines[i] = '';
+			continue;
+		}
+
+		// Must start with '(' to be a function-like macro invocation
+		if (!rest.startsWith('(')) continue;
+
+		// Walk balanced parentheses, respecting strings, to find the closing paren
+		let depth = 0;
+		let j = 0;
+		let inStr = false;
+		let strChar = '';
+		for (; j < rest.length; j++) {
+			const c = rest[j];
+			if (inStr) {
+				if (c === '\\') { j++; continue; }
+				if (c === strChar) inStr = false;
+				continue;
+			}
+			if (c === '"' || c === "'") { inStr = true; strChar = c; continue; }
+			if (c === '(') { depth++; continue; }
+			if (c === ')') {
+				depth--;
+				if (depth === 0) { j++; break; }
+			}
+		}
+
+		// Only strip if parens balanced and nothing (no semicolon) follows
+		if (depth === 0 && rest.slice(j).trim() === '') {
 			lines[i] = '';
 		}
 	}

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -3259,4 +3259,52 @@ void func()
 		const result = parse(code);
 		expect(result.syntaxErrors.length).toBe(0);
 	});
+
+	test("function-like macro with nested function call argument does not produce a syntax error", () => {
+		// MACRO_EXAMPLE(someOtherfunction()) — the argument contains nested parens.
+		// The old regex [^)]* stopped at the first ')' so the line was not stripped,
+		// causing a missing-semicolon syntax error on the following statement.
+		const code = `
+Integer someOtherfunction()
+{
+	return 1;
+}
+
+void func()
+{
+	#define MACRO_EXAMPLE(x) Integer test = x;
+
+	MACRO_EXAMPLE(someOtherfunction())
+
+	someOtherfunction();
+}
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("function-like macro with nested call does not produce false undeclared errors", () => {
+		const code = `
+Integer someOtherfunction()
+{
+	return 1;
+}
+
+void func()
+{
+	#define MACRO_EXAMPLE(x) Integer test = x;
+
+	MACRO_EXAMPLE(someOtherfunction())
+
+	someOtherfunction();
+}
+`;
+		const diagnostics = ValidateWithSymbols(code, {
+			functions: new Set(['someOtherfunction']),
+			variables: new Set(),
+			defines: new Set(['MACRO_EXAMPLE']),
+		});
+		const errors = diagnostics.filter(d => d.severity === 1 /* Error */);
+		expect(errors.length).toBe(0);
+	});
 });


### PR DESCRIPTION
Fixed multiple bracket pairs in pre proc macros causing invalid syntax errors