### PR TITLE
v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,12 +379,23 @@ Release of [v1.3.0] to the VS Code Marketplace.
 ### Changed
 - Completion provider no longer inserts full function snippets with parameter placeholders; signature help now provides that context inline as you type.
 ---
-## [v1.5.2] - (Date)
+
+## [v1.5.2] - (12/05/2026)
 
 ### New Features
 - **Preprocessor Definition Highlighting** (#119): Preprocessor definitions are now highlighted using semantic highlighting. Special thanks to @KleberNZ for his contribution.
 
 ---
+
+## [v1.5.3] - (18/05/2026)
+
+### Bug Fixes
+- **Nested Function variable definition checks** (#138): Functions nested in brackets are now all checked.
+- **Prototypes vs User Defined Functions** (#137): When a user defines an overload of a 12d prototype function the return types are now correctly checked.
+- **Block Comment Fix** (#136): When a block comment was used before a piece of valid code it was cleaned by the parser, this has now been corrected.
+
+---
+
 # Template
 
 ## [vX.X.X] - (Date)

--- a/client/testFixture/variable_redeclaration.4dm
+++ b/client/testFixture/variable_redeclaration.4dm
@@ -474,3 +474,14 @@ void main() {
 // - Variable/include shadowing checks are currently exact-case, not case-insensitive.
 //
 // ############################################################################
+
+/*global variables*/{
+    #define MAX_STRINGS 1500
+    #define MAX_OCC     30000
+
+    Real DROP_TOL = 0.005;
+    Real EPS_DEF  = 0.05;
+
+    Integer PIT_has_error[MAX_OCC+1];
+    Integer PIT_msg_count[MAX_OCC+1];
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	],
 	"license": "MIT",
 	"displayName": "12dPL Language",
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/ben-nightworks/12dpl-lang-server"

--- a/server/src/core/parsePipeline.ts
+++ b/server/src/core/parsePipeline.ts
@@ -122,6 +122,37 @@ export function wrapTopLevelScriptsPreservingLines(documentText: string): string
 	let awaitingFunctionBody = false;
 
 	const isLineStart = (i: number) => i === 0 || text[i - 1] === '\n' || text[i - 1] === '\r';
+
+	/**
+	 * True if only whitespace and closed block comments precede position i on its line.
+	 * This allows wrapping `{` that appears after a comment on the same line, e.g.:
+	 *   `/* Global variables *‌/ {`
+	 */
+	const isEffectiveLineStart = (i: number): boolean => {
+		if (isLineStart(i)) return true;
+		let j = i - 1;
+		while (j >= 0) {
+			const c = text[j];
+			if (c === '\n' || c === '\r') return true;
+			if (c === ' ' || c === '\t') { j--; continue; }
+			// Check for the end of a block comment: `*/`
+			if (c === '/' && j > 0 && text[j - 1] === '*') {
+				j -= 2; // move before the `*/`
+				// Walk backward to find the matching `/*`
+				while (j >= 1) {
+					if (text[j - 1] === '/' && text[j] === '*') {
+						j -= 2; // move before the `/*`
+						break;
+					}
+					j--;
+				}
+				continue;
+			}
+			return false;
+		}
+		return true; // reached start of file
+	};
+
 	const isIdentChar = (ch: string) => /[A-Za-z0-9_]/.test(ch);
 	const skipWhitespace = (i: number) => {
 		while (i < text.length && (text[i] === ' ' || text[i] === '\t')) i++;
@@ -209,7 +240,7 @@ export function wrapTopLevelScriptsPreservingLines(documentText: string): string
 				braceDepth === 0 &&
 				parenDepth === 0 &&
 				bracketDepth === 0 &&
-				isLineStart(i) &&
+				isEffectiveLineStart(i) &&
 				!tryMatchFunctionSignatureAt(i) &&
 				lineHasRealCode(i) &&
 				!inScriptWrapper

--- a/server/src/core/validation.UndeclaredSymbols.ts
+++ b/server/src/core/validation.UndeclaredSymbols.ts
@@ -263,7 +263,18 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 			for (const child of children) {
 				if (child && typeof child.accept === 'function') {
 					const isPrimary = child.ruleIndex !== undefined && child.constructor?.name === 'PrimaryExpressionContext';
-					if (!isPrimary) child.accept(visitor);
+					if (!isPrimary) {
+						child.accept(visitor);
+					} else {
+						// If the primary is a parenthesized expression '(expr)', visit the inner
+						// expression so undeclared symbols inside nested parens are still checked.
+						// Plain-identifier primaries (e.g. the function name) have no expression()
+						// child, so they are still skipped to avoid double-visiting.
+						const innerExpr = child?.expression?.();
+						if (innerExpr && typeof innerExpr.accept === 'function') {
+							innerExpr.accept(visitor);
+						}
+					}
 				}
 			}
 			return undefined;

--- a/server/src/core/validation.VoidReturnValue.ts
+++ b/server/src/core/validation.VoidReturnValue.ts
@@ -152,8 +152,10 @@ export function validateVoidFunctionReturnValues(
 	 * Returns undefined if the function is unknown.
 	 */
 	const resolveReturnType = (name: string, argCount: number): string | undefined => {
-		const overloads = localReturnTypes.get(name) ?? functionReturnTypes.get(name);
-		if (!overloads || overloads.length === 0) return undefined;
+		const localOverloads = localReturnTypes.get(name) ?? [];
+		const protoOverloads = functionReturnTypes.get(name) ?? [];
+		const overloads = [...localOverloads, ...protoOverloads];
+		if (overloads.length === 0) return undefined;
 
 		// Find overloads matching the argument count
 		const matching = overloads.filter(o => o.paramCount === argCount);

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -112,7 +112,7 @@ connection.onInitialize((params: InitializeParams) => {
 			textDocumentSync: TextDocumentSyncKind.Full,
 			completionProvider: {
 				resolveProvider: true,
-				triggerCharacters: ['"', "'", '<', '/']
+				triggerCharacters: ['"', "'", '<']
 			},
 			signatureHelpProvider: {
 				triggerCharacters: ['(', ','],

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -2076,6 +2076,27 @@ void test()
 		expect(diagnostics.length).toBe(1);
 		expect(diagnostics[0].message).toContain("mf");
 	});
+
+	test("does not flag call when local void overload shadows a non-void built-in with same arg count (issue #132)", () => {
+		// User defines void Create_text(5 params), built-in has Element Create_text(5 params).
+		// The call inside the function uses the built-in signature — should not be flagged.
+		const externalReturnTypes = new Map<string, OverloadReturnType[]>();
+		externalReturnTypes.set("Create_text", [
+			{ paramCount: 5, returnType: "Element" },
+		]);
+
+		const code = `
+void Create_text(Text text, Real x, Real y, Textstyle_Data txtstyl, Model model)
+{
+	Real txt_size;
+	Integer txt_colour;
+
+	Element text_elt = Create_text(text, x, y, txt_size, txt_colour);
+}
+`;
+		const diagnostics = ValidateVoidReturnValues(code, externalReturnTypes);
+		expect(diagnostics.length).toBe(0);
+	});
 });
 
 // ─── Function argument validation (#45) ─────────────────────────────────────

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -4000,3 +4000,49 @@ void main() {
 		expect(result.syntaxErrors.length).toBe(0);
 	});
 });
+
+describe("Top-level block comment before brace (issue #135)", () => {
+	test("no syntax errors for /* comment */ { ... } block", () => {
+		const code = `
+/* Global variables */ {
+    Integer Shutdown_code = 424242;
+}
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("no syntax errors for /*comment*/{ immediately adjacent }", () => {
+		const code = `
+/*global variables*/{
+    Integer x = 1;
+}
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("no syntax errors for multiple top-level comment blocks", () => {
+		const code = `
+/* Block 1 */ {
+    Integer a = 1;
+}
+
+/* Block 2 */ {
+    Integer b = 2;
+}
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("regular top-level brace block without comment still works", () => {
+		const code = `
+{
+    Integer x = 99;
+}
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+});

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -988,6 +988,70 @@ void main() {
 	});
 });
 
+describe("Undeclared symbols in nested parentheses (issue #134)", () => {
+	test("flags undeclared variables when call is wrapped in double parens", () => {
+		const code = `
+void Test()
+{
+    if ((Find_text(horiz_datum, "2020") && Find_text(projection_name, "2020")))
+    {
+    }
+}
+`;
+		const knownSymbols = {
+			functions: new Set(['Find_text']),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d => d.severity === 1 && d.message.includes("is not declared"));
+		expect(errors.some(d => d.message.includes("horiz_datum"))).toBe(true);
+		expect(errors.some(d => d.message.includes("projection_name"))).toBe(true);
+	});
+
+	test("flags undeclared variables in complex nested-paren conditions", () => {
+		const code = `
+void Test()
+{
+    if ((Find_text(horiz_datum, "2020") && Find_text(projection_name, "2020")) || (Find_text(horiz_datum, "94") && Find_text(projection_name, "94")))
+    {
+    }
+}
+`;
+		const knownSymbols = {
+			functions: new Set(['Find_text']),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d => d.severity === 1 && d.message.includes("is not declared"));
+		expect(errors.some(d => d.message.includes("horiz_datum"))).toBe(true);
+		expect(errors.some(d => d.message.includes("projection_name"))).toBe(true);
+	});
+
+	test("does not flag declared variables inside nested parens", () => {
+		const code = `
+void Test()
+{
+    Text horiz_datum;
+    Text projection_name;
+    if ((Find_text(horiz_datum, "2020") && Find_text(projection_name, "2020")))
+    {
+    }
+}
+`;
+		const knownSymbols = {
+			functions: new Set(['Find_text']),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d => d.severity === 1 && d.message.includes("is not declared"));
+		expect(errors.some(d => d.message.includes("horiz_datum"))).toBe(false);
+		expect(errors.some(d => d.message.includes("projection_name"))).toBe(false);
+	});
+});
+
 describe("KnownSymbols validation (PR #30 refactor)", () => {
 	// =========================================================================
 	// Known Functions Tests


### PR DESCRIPTION
### Bug Fixes
- **Nested Function variable definition checks** (#138): Functions nested in brackets are now all checked.
- **Prototypes vs User Defined Functions** (#137): When a user defines an overload of a 12d prototype function the return types are now correctly checked.
- **Block Comment Fix** (#136): When a block comment was used before a piece of valid code it was cleaned by the parser, this has now been corrected.