### PR TITLE
v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -396,6 +396,17 @@ Release of [v1.3.0] to the VS Code Marketplace.
 
 ---
 
+## [v1.5.4] - (24/05/2026)
+
+### New Features
+- **Preprocessor Macro Substitution** (#144): Preprocessor macros are now expanded during validation, allowing the validator to correctly analyse code that uses macro-defined values. The original symbols are preserved alongside the expanded forms so completion and hover continue to work on macro names.
+
+### Bug Fixes
+- **Block Comment Bracket Colours** (#143): Brackets inside block comments are no longer coloured as code brackets by the syntax highlighter.
+- **Forward Declaration False Positive** (#142): Functions forward-declared in a header file no longer incorrectly trigger a redeclaration error when the same function is also defined in the same or an included file.
+
+---
+
 # Template
 
 ## [vX.X.X] - (Date)

--- a/README.md
+++ b/README.md
@@ -28,37 +28,35 @@ This repository’s documentation is split into the following Markdown files:
 - **AST Parsing** - Complete abstract syntax tree generation
 - **Function Documentation** - Hover over builtins, local symbols, include symbols, and `#define` macros
 - **Go to Definition** - Works for local symbols and across included files (including `#define` macros)
-- **Formatting** - Basic brace-based formatting (supports format-on-save)
-- **Preprocessor Support** - `#include`/`#define` suggestions, include-path completion, and macro completion
-- **Fuzzy Matching** - IntelliSense-like fuzzy matching for completion results
+- **Signature Help** - Parameter info tooltip appears as you type, with active parameter highlighted and all overloads shown
+- **Rename All Symbols** - Scope-aware rename across the current file (F2 or right-click > Rename Symbol)
+- **Formatting** - Brace-based formatting with configurable bracket style, indent style, and line-length wrapping (supports format-on-save)
+- **Preprocessor Support** - `#include`/`#define` suggestions, include-path completion, macro completion, and macro expansion during validation
 - **Advanced Grammar Support** - Arrays, Switch statements, Pass-by-reference, Macros
-- **Goto Definition** - Navigation to definitions 
+- **Document Outline** - Functions and global variables shown in the VS Code outline panel and breadcrumb bar
+- **Semantic Highlighting** - Macro definitions and uppercase constants are highlighted distinctly
+- **Control Flow Validation** - Detects unreachable code, missing `break` in `switch` cases, and `switch` without `default`
+- **Assignment Type Validation** - Reports type mismatches and lossy promotions in assignments
+- **Logical Condition Validation** - Warns on non-boolean loop/condition expressions
+- **Array Size Validation** - Flags unsized array declarations in function bodies
+- **Undeclared Symbol Detection** - Flags calls to functions not declared locally, in headers, or in built-in prototypes
 
 ### Coming Soon
-- Document Highlights: highlights all 'equal' symbols in a text document
-- Signature Help: provides signature help during function calls
+- Document Highlights: highlights all matching symbols in a text document
 - Find References: find all references to a symbol
-- List Document Symbols: lists all symbols in current document
 - List Workspace Symbols: lists all project-wide symbols
-- Rename: project-wide symbol renaming
 
 ---
 
-### What's New in v1.3.0
+### What's New in v1.5.4
 
-**Enhanced Validation & Type System** ✨
-- **Advanced Function Argument Validation** — Validates argument types against function signatures with type promotion support
-- **Return Type Validation** — Checks that return values match function return types and handles void functions correctly
-- **Type Inheritance** — Proper type hierarchy support (e.g., Panel inherits from Widget) with automatic type promotion
-- **Scope-Aware Validation** — Improved variable and function definition tracking to reduce false errors
-- **Function Overloading** — Full support for functions with the same name but different parameter signatures
-- **Case Sensitivity Fixes** — Proper handling of type and symbol name resolution
+**Preprocessor Macro Substitution** ✨
+- Macros are now expanded during validation so the validator correctly analyses code that uses macro-defined values
+- Original macro symbols are preserved alongside expanded forms, keeping completion and hover working on macro names
 
-**Architectural Improvements**
-- Refactored validator infrastructure for easier extension
-- Enhanced symbol collection and caching
-- Better include-file integration
-
+**Bug Fixes**
+- Block comment bracket colours: brackets inside block comments are no longer coloured as code brackets
+- Forward declaration false positives in header files are no longer incorrectly reported as redeclarations
 
 
 

--- a/client/testFixture/function_redeclaration.4dm
+++ b/client/testFixture/function_redeclaration.4dm
@@ -14,6 +14,7 @@
 //   - Forward declaration followed by full definition (same signature)
 //   - Forward declaration after full definition (silently ignored)
 //   - Functions on conditional (#if/#ifdef) lines (suppressed)
+//   - Full definition of a function only forward-declared in an include file (issue #141)
 //
 // Parameter signature = parameter types + array-ness (return type is irrelevant)
 //
@@ -96,18 +97,19 @@ void duplicate() // ERROR: already defined
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
-// TEST 6: Include file conflict → ERROR
-// test_globals.h declares:
+// TEST 6: Include forward declaration + full definition → OK (issue #141)
+// test_globals.h declares forward prototypes only:
 //   void test_include_case_insensitive(Integer x);
 //   void test_include_case_insensitive();
-// Re-defining the same signatures here triggers include conflict errors.
+// Providing a full definition for a forward-declared prototype is the standard
+// C-style header + code pattern and is NOT an error.
 // ──────────────────────────────────────────────────────────────────────────────
 
-void test_include_case_insensitive(Integer x) // ERROR: already defined in test_globals.h
+void test_include_case_insensitive(Integer x) // OK: implementing a forward prototype from test_globals.h
 {
 }
 
-void test_include_case_insensitive() // ERROR: already defined in test_globals.h
+void test_include_case_insensitive() // OK: implementing a forward prototype from test_globals.h
 {
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	],
 	"license": "MIT",
 	"displayName": "12dPL Language",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/ben-nightworks/12dpl-lang-server"

--- a/server/src/core/parsePipeline.ts
+++ b/server/src/core/parsePipeline.ts
@@ -330,6 +330,64 @@ export function wrapTopLevelScriptsPreservingLines(documentText: string): string
 }
 
 /**
+ * Expands object-like (no-parameter) `#define` macros by substituting their names
+ * with their values throughout the stripped text.
+ *
+ * This allows patterns such as:
+ * ```
+ * #define Boolean Integer
+ * Boolean active = TRUE;
+ * ```
+ * to parse correctly as `Integer active = TRUE;`.
+ *
+ * Only object-like macros are expanded -- those without a parameter list immediately
+ * after the name. Function-like macros (e.g. `#define MACRO(x) ...`) and macros with
+ * backslash-continuation values are skipped.
+ *
+ * This function is applied to the text fed to ANTLR for parsing. The original
+ * (unexpanded) token stream is preserved separately for token-based features such
+ * as rename and deprecated-call detection. See `parse()` for the dual-text strategy.
+ *
+ * Line numbers are preserved because substitutions never add or remove newlines.
+ *
+ * @param strippedText - Text after standalone macro usages have been stripped.
+ * @param rawText - The original document text, used to extract define definitions.
+ */
+export function expandObjectLikeMacros(strippedText: string, rawText: string): string {
+	// Collect object-like defines: #define NAME value
+	// A define is function-like (and must be skipped) when '(' appears immediately after NAME.
+	const defines: Array<{ name: string; value: string }> = [];
+	const lines = rawText.split(/\r?\n/);
+
+	for (const line of lines) {
+		// Match: #define NAME<no '(' here> <whitespace> value
+		const m = line.match(/^\s*#\s*define\s+([A-Za-z_][A-Za-z0-9_]*)(?!\()[ \t]+(.+\S)/);
+		if (!m) continue;
+		const name = m[1];
+		const value = m[2].trim();
+		// Skip multi-line macro values (backslash continuation)
+		if (value.endsWith('\\')) continue;
+		defines.push({ name, value });
+	}
+
+	if (defines.length === 0) return strippedText;
+
+	// Apply whole-word substitutions in order of definition.
+	// Use a function replacement to avoid special `$` patterns in replacement strings.
+	let result = strippedText;
+	for (const { name, value } of defines) {
+		const re = new RegExp(`\\b${escapeRegExp(name)}\\b`, 'g');
+		result = result.replace(re, () => value);
+	}
+
+	return result;
+}
+
+function escapeRegExp(s: string): string {
+	return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Replaces standalone macro usage lines with empty lines to prevent ANTLR parse errors.
  *
  * When a `#define MACRO_NAME ...` is used as a statement on its own line (e.g. `MACRO_EXAMPLE`
@@ -427,8 +485,24 @@ class SyntaxErrorListener implements ErrorListener<any> {
  */
 export function parse(documentText: string): ParseResult {
 	const { text: strippedText, conditionalLines } = stripConditionalDirectives(documentText);
+
+	// Strip standalone macro calls first -- shared step for both paths below.
 	const macroStrippedText = stripStandaloneMacroUsages(strippedText, documentText);
-	const transformedText = wrapTopLevelScriptsPreservingLines(macroStrippedText);
+
+	// -- Original path: lex the unexpanded text to produce the token stream --
+	// Preserves original token names (MAX_SIZE, TIMEOUT, ...) so that rename and
+	// deprecated-call detection can find them by name in the source.
+	const originalTransformed = wrapTopLevelScriptsPreservingLines(macroStrippedText);
+	const originalLexer = new proglang12dLexer(new CharStream(originalTransformed));
+	const originalTokens = new CommonTokenStream(originalLexer);
+	originalTokens.fill();
+
+	// -- Expanded path: expand all object-like macros before parsing --
+	// The ANTLR parser receives e.g. `Integer` instead of `Boolean`, so
+	// type-alias defines and other object-like substitutions do not produce
+	// spurious syntax errors.
+	const expandedText = expandObjectLikeMacros(macroStrippedText, documentText);
+	const transformedText = wrapTopLevelScriptsPreservingLines(expandedText);
 
 	const chars = new CharStream(transformedText);
 	const lexer = new proglang12dLexer(chars);
@@ -445,7 +519,7 @@ export function parse(documentText: string): ParseResult {
 
 	return {
 		tree,
-		tokens,
+		tokens: originalTokens,
 		transformedText,
 		conditionalLines,
 		syntaxErrors: errorListener.errors,

--- a/server/src/core/validation.FunctionRedeclaration.ts
+++ b/server/src/core/validation.FunctionRedeclaration.ts
@@ -73,17 +73,18 @@ export function validateFunctionRedeclarations(
 	// Map from name → array of { signature, line, column, name, isForwardDecl }
 	const definedFunctions = new Map<string, { signature: string; line: number; column: number; name: string; isForwardDecl: boolean }[]>();
 
-	// Track functions from include files: name → array of { sourceFile, signature }
-	const includeFunctions = new Map<string, { sourceFile: string; signature: string }[]>();
+	// Track functions from include files: name → array of { sourceFile, signature, isForwardDecl }
+	const includeFunctions = new Map<string, { sourceFile: string; signature: string; isForwardDecl: boolean }[]>();
 	for (const decl of includeDeclarations) {
 		if (decl.kind === 'function') {
 			const sig = (decl.params ?? []).map(p => {
 				const typeStr = p.type ?? '';
 				return typeStr + (p.isArray ? '[]' : '');
 			}).join(',');
+			const isForwardDecl = decl.isForwardDeclaration ?? false;
 			const existing = includeFunctions.get(decl.name);
-			if (existing) existing.push({ sourceFile: decl.definedInFsPath ?? '', signature: sig });
-			else includeFunctions.set(decl.name, [{ sourceFile: decl.definedInFsPath ?? '', signature: sig }]);
+			if (existing) existing.push({ sourceFile: decl.definedInFsPath ?? '', signature: sig, isForwardDecl });
+			else includeFunctions.set(decl.name, [{ sourceFile: decl.definedInFsPath ?? '', signature: sig, isForwardDecl }]);
 		}
 	}
 
@@ -98,12 +99,14 @@ export function validateFunctionRedeclarations(
 		const paramSig = extractParamSignature(declaratorCtx);
 		const existing = definedFunctions.get(info.name);
 
-		// 1. Always check against include files — every occurrence that matches is an error
+		// 1. Always check against include files — every occurrence that matches is an error,
+		//    EXCEPT when the include entry is only a forward declaration and the current
+		//    occurrence is a full definition (standard C-style header + code pattern, issue #141).
 		let hasIncludeConflict = false;
 		const includeOverloads = includeFunctions.get(info.name);
 		if (includeOverloads && !isOnConditionalLine) {
 			const includeMatch = includeOverloads.find(o => o.signature === paramSig);
-			if (includeMatch) {
+			if (includeMatch && !(includeMatch.isForwardDecl && !isForwardDecl)) {
 				hasIncludeConflict = true;
 				diagnostics.push({
 					severity: DiagnosticSeverity.Error,

--- a/syntax/12dpl.tmLanguage.json
+++ b/syntax/12dpl.tmLanguage.json
@@ -534,7 +534,13 @@
 							"name": "punctuation.definition.comment.end.12dpl"
 						}
 					},
-					"name": "comment.block.12dpl"
+					"name": "comment.block.12dpl",
+					"patterns": [
+						{
+							"match": "[{}()[\\]]",
+							"name": "comment.block.12dpl"
+						}
+					]
 				},
 				{
 					"begin": "\\s*+(\\/\\*)",
@@ -549,7 +555,13 @@
 							"name": "punctuation.definition.comment.end.12dpl"
 						}
 					},
-					"name": "comment.block.12dpl"
+					"name": "comment.block.12dpl",
+					"patterns": [
+						{
+							"match": "[{}()[\\]]",
+							"name": "comment.block.12dpl"
+						}
+					]
 				}
 			]
 		},
@@ -995,7 +1007,13 @@
 										"1": {
 											"name": "punctuation.definition.comment.end.12dpl"
 										}
-									}
+									},
+									"patterns": [
+										{
+											"match": "[{}()[\\]]",
+											"name": "comment.block.12dpl"
+										}
+									]
 								},
 								{
 									"match": "^\\/\\/ =(\\s*.*?)\\s*=$\\n?",

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -740,6 +740,56 @@ void process(Integer x, Integer y) {
 		expect(redeclErrors.length).toBe(0);
 	});
 
+	test("allows full definition of function only forward-declared in header (issue #141)", () => {
+		// Standard C-style header + code pattern:
+		//   test.h: Integer Test(Text test);          ← forward declaration only
+		//   test.4dm: #include "test.h" + full definition
+		const includeVars: SymbolDeclaration[] = [
+			{
+				...includeDecl('Test', 'test.h', 'function', [
+					{ name: 'test', type: 'Text', byRef: false, isArray: false }
+				]),
+				isForwardDeclaration: true
+			}
+		];
+
+		const code = `
+Integer Test(Text test) {
+	return 0;
+}
+`;
+		const diagnostics = ValidateWithIncludes(code, includeVars);
+		const redeclErrors = diagnostics.filter(d =>
+			d.severity === 1 /* Error */ && d.message.includes("already defined")
+		);
+		expect(redeclErrors.length).toBe(0);
+	});
+
+	test("still errors when include has a full definition and code file redefines it (issue #141)", () => {
+		// If the include file has a full function definition (not just a prototype),
+		// redefining it in the code file should still be an error.
+		const includeVars: SymbolDeclaration[] = [
+			{
+				...includeDecl('Test', 'test.h', 'function', [
+					{ name: 'test', type: 'Text', byRef: false, isArray: false }
+				]),
+				isForwardDeclaration: false
+			}
+		];
+
+		const code = `
+Integer Test(Text test) {
+	return 0;
+}
+`;
+		const diagnostics = ValidateWithIncludes(code, includeVars);
+		const redeclErrors = diagnostics.filter(d =>
+			d.severity === 1 /* Error */ && d.message.includes("already defined")
+		);
+		expect(redeclErrors.length).toBe(1);
+		expect(redeclErrors[0].message).toContain("test.h");
+	});
+
 	test("does not flag function redeclaration in #if/#else conditional branches", () => {
 		const code = `
 #if USE_NEW == 1

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { describe, expect, test } from "bun:test";
-import { parse } from "../server/src/core/parsePipeline";
+import { parse, expandObjectLikeMacros } from "../server/src/core/parsePipeline";
 import { collectSymbolTable, deriveViews, parseDefines } from "../server/src/core/symbolCollector";
 import { validateVariableRedeclarations, validateFunctionRedeclarations, validateUndeclaredIdentifiers, validateDeprecatedCalls, validateVoidFunctionReturnValues, FunctionSignatureMap, validateFunctionArguments, validateReturnStatements, validateArraySize } from "../server/src/core/validators";
 import type { OverloadReturnType } from "../server/src/core/validators";
@@ -4131,3 +4131,83 @@ describe("Top-level block comment before brace (issue #135)", () => {
 		expect(result.syntaxErrors.length).toBe(0);
 	});
 });
+
+// ─── #define type substitution (issue #133) ──────────────────────────────────
+//
+// Object-like #defines whose value is a built-in type name must be expanded
+// before parsing so that e.g. `Boolean active = TRUE;` is parsed as
+// `Integer active = TRUE;` and does not produce a syntax error.
+
+describe("#define type substitution — expandObjectLikeMacros (issue #133)", () => {
+	test("type alias define allows variable declaration without syntax error", () => {
+		const code = `
+#define Boolean Integer
+#define TRUE 1
+#define FALSE 0
+Boolean active = TRUE;
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("type alias define allows function return type without syntax error", () => {
+		const code = `
+#define Boolean Integer
+Boolean is_active()
+{
+    return 1;
+}
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("type alias define allows function parameter type without syntax error", () => {
+		const code = `
+#define Boolean Integer
+void set_flag(Boolean value)
+{
+    Integer x = value;
+}
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("expandObjectLikeMacros replaces type alias with whole-word matching", () => {
+		const raw = `#define Boolean Integer\nBoolean active = 1;\nInteger BigBoolean = 2;\n`;
+		const stripped = raw.replace(/^\s*#\s*define\b.*$/gm, '');
+		const expanded = expandObjectLikeMacros(stripped, raw);
+		expect(expanded).toContain('Integer active = 1;');
+		// Should NOT replace inside longer identifiers
+		expect(expanded).toContain('Integer BigBoolean = 2;');
+	});
+
+	test("expandObjectLikeMacros skips function-like macros", () => {
+		const raw = `#define MACRO(x) x + 1\nInteger y = MACRO(5);\n`;
+		const stripped = raw.replace(/^\s*#\s*define\b.*$/gm, '');
+		const expanded = expandObjectLikeMacros(stripped, raw);
+		// MACRO should not be expanded since it's function-like
+		expect(expanded).toContain('MACRO(5)');
+	});
+
+	test("expandObjectLikeMacros expands constant (non-type) defines too", () => {
+		const raw = `#define MAX_SIZE 100\nInteger x = MAX_SIZE;\n`;
+		const stripped = raw.replace(/^\s*#\s*define\b.*$/gm, '');
+		const expanded = expandObjectLikeMacros(stripped, raw);
+		// MAX_SIZE should be expanded to 100 in the parse text
+		expect(expanded).toContain('Integer x = 100;');
+	});
+
+	test("multiple type alias defines in same file all expanded", () => {
+		const code = `
+#define Boolean Integer
+#define Number Real
+Boolean flag = 1;
+Number value = 3.14;
+`;
+		const result = parse(code);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+});
+


### PR DESCRIPTION
**Preprocessor Macro Substitution**
- Macros are now expanded during validation so the validator correctly analyses code that uses macro-defined values
- Original macro symbols are preserved alongside expanded forms, keeping completion and hover working on macro names

**Bug Fixes**
- Block comment bracket colours: brackets inside block comments are no longer coloured as code brackets
- Forward declaration false positives in header files are no longer incorrectly reported as redeclarations
