### PR TITLE
v1.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -414,6 +414,18 @@ Release of [v1.3.0] to the VS Code Marketplace.
 
 ---
 
+## [v1.5.6] - (28/05/2026)
+
+### New Features
+- **Temporary Value Warnings for Pass-by-Reference** (#151): A warning is now emitted when a literal or temporary value is passed to a `&` (pass-by-reference) parameter, since the callee cannot meaningfully write back to a temporary.
+- **Block-Scope Variable Leak Detection** (#150): Variables declared inside a block (e.g. `if`, `for`) are no longer considered accessible outside that block. Using such a variable after its scope ends is now reported as an undeclared-symbol error.
+- **Preprocessor Defines from Headers** (#155): The validation pipeline now performs a double parse so that `#define` statements from included header files are collected and substituted before the main validation pass, resolving false positives caused by macro-defined values from headers.
+
+### Bug Fixes
+- **Switch Statement Formatting**: Switch cases with compound bodies were indented incorrectly by the formatter; this has been corrected.
+
+---
+
 # Template
 
 ## [vX.X.X] - (Date)

--- a/README.md
+++ b/README.md
@@ -48,15 +48,19 @@ This repository’s documentation is split into the following Markdown files:
 
 ---
 
-### What's New in v1.5.4
+### What's New in v1.5.6
 
-**Preprocessor Macro Substitution** ✨
-- Macros are now expanded during validation so the validator correctly analyses code that uses macro-defined values
-- Original macro symbols are preserved alongside expanded forms, keeping completion and hover working on macro names
+**Pass-by-Reference Temporary Value Warnings** ✨
+- Passing a literal or temporary value to a `&` (pass-by-reference) parameter now produces a warning, since the callee cannot write back to a temporary
+
+**Block-Scope Variable Leak Detection** ✨
+- Variables declared inside a block (`if`, `for`, etc.) are no longer accessible outside that block; using them after scope ends is reported as an error
+
+**Preprocessor Defines from Headers** ✨
+- `#define` macros from included header files are now collected and substituted before validation, eliminating false positives from macro-defined values in headers
 
 **Bug Fixes**
-- Block comment bracket colours: brackets inside block comments are no longer coloured as code brackets
-- Forward declaration false positives in header files are no longer incorrectly reported as redeclarations
+- Switch statement formatting: cases with compound bodies are now indented correctly
 
 
 

--- a/client/testFixture/formatting.4dm
+++ b/client/testFixture/formatting.4dm
@@ -18,5 +18,17 @@ Integer param7, Integer param8, Integer param9, Integer param10)
 void main()
 {
 	Integer result = my_func(5, 10);
-		
+	switch(result)
+	{
+		case 15:
+		{
+			// This is a case for when the result is 15. It should be properly indented and formatted.
+			break;
+		}
+		default:
+		{
+			// This is the default case. It should also be properly indented and formatted.
+			break;
+		}
+	}
 }

--- a/client/testFixture/function_arguments.4dm
+++ b/client/testFixture/function_arguments.4dm
@@ -208,6 +208,33 @@ void test_unknown_function()
 	unknown_function(1, 2, 3); // No argument error here; full pipeline still reports undeclared function
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// TEST 12: Reference parameter receives a temporary value → WARNING (issue #151)
+// Passing a literal to a byRef parameter should produce a warning.
+// ──────────────────────────────────────────────────────────────────────────────
+
+void takes_ref_real(Real &x)
+{
+}
+
+void takes_two_refs(Integer &a, Integer &b)
+{
+}
+
+void takes_ref_text(Text &msg)
+{
+}
+
+void test_ref_temporary()
+{
+	Integer val = 5;
+	takes_ref(0);              // WARNING: argument 1 is a reference but value is a temporary
+	takes_ref(val);            // OK: variable is an lvalue
+	takes_two_refs(1, 2);      // WARNING x2: both arguments are temporaries
+	takes_ref_real(3.14);      // WARNING: real literal passed to Real& param
+	takes_ref_text("hello");   // WARNING: text literal passed to Text& param
+}
+
 void main()
 {
 }
@@ -228,6 +255,11 @@ void main()
 //   TEST 7:  overloaded(1,2,3) — no matching overload
 //   TEST 11: unknown_function(1,2,3) — undeclared function (from undeclared-symbol validator)
 //
+// WARNINGS:
+//   TEST 12: takes_ref(0) — argument 1 is a reference but value is a temporary
+//   TEST 12: takes_two_refs(1, 2) — argument 1 and argument 2 are references but values are temporaries
+//   TEST 12: takes_ref_real(3.14) — argument 1 is a reference but value is a temporary
+//
 // OK (no diagnostic):
 //   TEST 1:  Correct argument counts
 //   TEST 3:  Correct argument types (variables and literals)
@@ -237,6 +269,7 @@ void main()
 //   TEST 9:  Return type resolution nested in arguments
 //   TEST 10: Literal promotion in overload context
 //   TEST 11: No argument-count/type diagnostic from this validator
+//   TEST 12: takes_ref(val) — variable is lvalue, no warning
 //
 // ============================================================================
 void Process(Element e)

--- a/client/testFixture/includes/boolean_types.h
+++ b/client/testFixture/includes/boolean_types.h
@@ -1,0 +1,16 @@
+#ifndef BOOLEAN_TYPES_H
+#define BOOLEAN_TYPES_H
+
+#ifndef Boolean
+#define Boolean Integer
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#endif

--- a/client/testFixture/undeclared_symbols.4dm
+++ b/client/testFixture/undeclared_symbols.4dm
@@ -206,6 +206,33 @@ void main()
 {
 }
 
+// ──────────────────────────────────────────────────────────────────────────────
+// TEST 15: Variable declared inside if-block is not accessible outside (issue #150)
+// ──────────────────────────────────────────────────────────────────────────────
+
+void test_if_block_scope()
+{
+	if (1 == 1)
+	{
+		Integer block_var = 99;
+	}
+	Integer x = block_var;              // ERROR: 'block_var' not declared in this scope
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TEST 16: Variable declared before if-block remains in scope after
+// ──────────────────────────────────────────────────────────────────────────────
+
+void test_outer_scope_persists()
+{
+	Integer outer = 10;
+	if (outer > 5)
+	{
+		Integer inner = outer + 1;      // OK: outer declared in function scope
+	}
+	Integer z = outer;                  // OK: outer still in scope after if-block
+}
+
 // ============================================================================
 // EXPECTED DIAGNOSTICS SUMMARY
 // ============================================================================
@@ -219,6 +246,7 @@ void main()
 //   TEST 8:  'MYVAR' is not declared (case mismatch)
 //   TEST 12: 'undeclared_1' is not declared
 //   TEST 12: 'undeclared_2' is not declared
+//   TEST 15: 'block_var' is not declared (used outside if-block scope)
 //
 // WARNINGS:
 //   TEST 9:  Case type mismatch: Integer switch, Text case ("text")
@@ -234,5 +262,6 @@ void main()
 //   TEST 11: Function-like macro arguments (suppressed)
 //   TEST 13: Global variables accessible in functions
 //   TEST 14: Local function calls
+//   TEST 16: Variable declared before if-block remains in scope after
 //
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	],
 	"license": "MIT",
 	"displayName": "12dPL Language",
-	"version": "1.5.5",
+	"version": "1.5.6",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/ben-nightworks/12dpl-lang-server"

--- a/server/src/core/parsePipeline.ts
+++ b/server/src/core/parsePipeline.ts
@@ -353,7 +353,11 @@ export function wrapTopLevelScriptsPreservingLines(documentText: string): string
  * @param strippedText - Text after standalone macro usages have been stripped.
  * @param rawText - The original document text, used to extract define definitions.
  */
-export function expandObjectLikeMacros(strippedText: string, rawText: string): string {
+export function expandObjectLikeMacros(
+	strippedText: string,
+	rawText: string,
+	extraDefines?: readonly { name: string; value: string }[]
+): string {
 	// Collect object-like defines: #define NAME value
 	// A define is function-like (and must be skipped) when '(' appears immediately after NAME.
 	const defines: Array<{ name: string; value: string }> = [];
@@ -368,6 +372,17 @@ export function expandObjectLikeMacros(strippedText: string, rawText: string): s
 		// Skip multi-line macro values (backslash continuation)
 		if (value.endsWith('\\')) continue;
 		defines.push({ name, value });
+	}
+
+	// Prepend extra defines (e.g. from included header files), deduplicating by name.
+	// Local defines take precedence over extra defines.
+	if (extraDefines && extraDefines.length > 0) {
+		const localNames = new Set(defines.map(d => d.name));
+		for (const d of extraDefines) {
+			if (!localNames.has(d.name)) {
+				defines.unshift(d);
+			}
+		}
 	}
 
 	if (defines.length === 0) return strippedText;
@@ -398,13 +413,20 @@ function escapeRegExp(s: string): string {
  * @param strippedText - Text after `stripConditionalDirectives` (define lines already empty).
  * @param rawText - The original document text, used to extract define names.
  */
-export function stripStandaloneMacroUsages(strippedText: string, rawText: string): string {
+export function stripStandaloneMacroUsages(
+	strippedText: string,
+	rawText: string,
+	extraDefineNames?: readonly string[]
+): string {
 	// Collect all define names from the original (unstripped) text
 	const defineNames = new Set<string>();
 	const defineRe = /^\s*#\s*define\s+([A-Za-z_][A-Za-z0-9_]*)/gm;
 	let m: RegExpExecArray | null;
 	while ((m = defineRe.exec(rawText)) !== null) {
 		defineNames.add(m[1]);
+	}
+	if (extraDefineNames) {
+		for (const name of extraDefineNames) defineNames.add(name);
 	}
 	if (defineNames.size === 0) return strippedText;
 
@@ -483,11 +505,18 @@ class SyntaxErrorListener implements ErrorListener<any> {
  * Performs preprocessing (strip conditionals, wrap scripts) then ANTLR lexing/parsing.
  * The returned result is the single artifact all downstream consumers share.
  */
-export function parse(documentText: string): ParseResult {
+export function parse(
+	documentText: string,
+	extraDefines?: readonly { name: string; value: string }[]
+): ParseResult {
 	const { text: strippedText, conditionalLines } = stripConditionalDirectives(documentText);
 
 	// Strip standalone macro calls first -- shared step for both paths below.
-	const macroStrippedText = stripStandaloneMacroUsages(strippedText, documentText);
+	const macroStrippedText = stripStandaloneMacroUsages(
+		strippedText,
+		documentText,
+		extraDefines?.map(d => d.name)
+	);
 
 	// -- Original path: lex the unexpanded text to produce the token stream --
 	// Preserves original token names (MAX_SIZE, TIMEOUT, ...) so that rename and
@@ -501,7 +530,7 @@ export function parse(documentText: string): ParseResult {
 	// The ANTLR parser receives e.g. `Integer` instead of `Boolean`, so
 	// type-alias defines and other object-like substitutions do not produce
 	// spurious syntax errors.
-	const expandedText = expandObjectLikeMacros(macroStrippedText, documentText);
+	const expandedText = expandObjectLikeMacros(macroStrippedText, documentText, extraDefines);
 	const transformedText = wrapTopLevelScriptsPreservingLines(expandedText);
 
 	const chars = new CharStream(transformedText);

--- a/server/src/core/validation.FunctionArguments.ts
+++ b/server/src/core/validation.FunctionArguments.ts
@@ -66,6 +66,30 @@ function formatParamTypes(params: ParamList): string {
 }
 
 /**
+ * Returns true if the expression is definitely a temporary (not an lvalue).
+ * Only flags obvious cases: numeric and string literals (optionally negated).
+ * Used to detect passing a temporary to a reference parameter.
+ */
+function isTemporaryExpression(argCtx: any): boolean {
+	try {
+		const text = argCtx?.getText?.();
+		if (!text) return false;
+
+		// String literal
+		if (text.startsWith('"') && text.endsWith('"')) return true;
+
+		// Integer literal (optionally negated, including hex)
+		if (/^-?[0-9]+$/.test(text)) return true;
+		if (/^-?0x[0-9a-fA-F]+$/i.test(text)) return true;
+
+		// Real literal (optionally negated)
+		if (/^-?[0-9]*\.[0-9]+$/.test(text)) return true;
+
+		return false;
+	} catch { return false; }
+}
+
+/**
  * Checks whether a given argument type is compatible with a parameter type.
  * In 12dPL, Integer and Real are numerically compatible.
  */
@@ -355,6 +379,30 @@ export function validateFunctionArguments(
 								end: { line: line - 1, character: column + funcName.length }
 							},
 							message: `Function call '${funcName}' args mismatch — got (${argTypeStr}), expected ${expectedSigs}`
+						});
+					}
+
+					// Check: reference parameter receives a temporary value.
+					// Only warn if ALL count-matching overloads require byRef at this position,
+					// so that a non-byRef overload suppresses the warning.
+					for (let i = 0; i < argExprs.length; i++) {
+						const allByRef = countMatches.every(params => params[i]?.byRef === true);
+						if (!allByRef) continue;
+						if (!isTemporaryExpression(argExprs[i])) continue;
+
+						const argStart = argExprs[i]?.start;
+						const argLine = argStart?.line ?? null;
+						const argColumn = argStart?.column ?? null;
+						if (argLine === null || argColumn === null) continue;
+
+						const argText = argExprs[i]?.getText?.() ?? '';
+						diagnostics.push({
+							severity: DiagnosticSeverity.Warning,
+							range: {
+								start: { line: argLine - 1, character: argColumn },
+								end: { line: argLine - 1, character: argColumn + argText.length }
+							},
+							message: `Argument ${i + 1} of '${funcName}' is a reference parameter but value is a temporary`
 						});
 					}
 				}

--- a/server/src/core/validation.UndeclaredSymbols.ts
+++ b/server/src/core/validation.UndeclaredSymbols.ts
@@ -29,6 +29,7 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 	// Scope stack: index 0 is the global scope, higher indices are nested scopes.
 	const scopeStack: Map<string, DeclaredSymbol>[] = [new Map()];
 	let inWrapperFunction = false;
+	let inFunctionBody = false;
 
 	const pushScope = () => { scopeStack.push(new Map()); };
 	const popScope = () => { if (scopeStack.length > 1) scopeStack.pop(); };
@@ -156,14 +157,40 @@ export function validateUndeclaredIdentifiers(tree: any, knownSymbols: KnownSymb
 			if (info) scopeStack[0].set(funcName, info);
 
 			const prevWrapper = inWrapperFunction;
+			const prevInFunctionBody = inFunctionBody;
 			inWrapperFunction = funcName.startsWith('__12dpl__');
 
 			pushScope();
+			inFunctionBody = true;
 			visitor.visitChildren(ctx);
+			inFunctionBody = false;
 			popScope();
 
 			inWrapperFunction = prevWrapper;
+			inFunctionBody = prevInFunctionBody;
 			return undefined;
+		},
+		visitCompoundStatement(ctx: any) {
+			if (inFunctionBody) {
+				inFunctionBody = false;
+				visitor.visitChildren(ctx);
+				return undefined;
+			}
+			pushScope();
+			visitor.visitChildren(ctx);
+			popScope();
+			return undefined;
+		},
+		visitIterationStatement(ctx: any) {
+			try {
+				if (ctx?.For?.()) {
+					pushScope();
+					visitor.visitChildren(ctx);
+					popScope();
+					return undefined;
+				}
+			} catch { /* ignore */ }
+			return visitor.visitChildren(ctx);
 		},
 		visitDeclaration(ctx: any) {
 			const declType = getDeclarationTypeText(ctx);

--- a/server/src/services/diagnosticService.ts
+++ b/server/src/services/diagnosticService.ts
@@ -9,6 +9,7 @@ import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node';
 import type { DocumentService } from './documentService';
 import type { IncludeService } from './includeService';
 import type { PrototypeService } from './prototypeService';
+import { parse } from '../core/parsePipeline';
 import { validateVariableRedeclarations, 
 	validateFunctionRedeclarations, 
 	validateUndeclaredIdentifiers, 
@@ -32,7 +33,25 @@ export class DiagnosticService {
 
 	/** Returns all diagnostics for a document. Single entry point. */
 	async validate(uri: string): Promise<Diagnostic[]> {
-		const parseResult = this.documentService.getParseResult(uri);
+		// Resolve include-file defines before parsing so that object-like macros
+		// defined in headers (e.g. `#define Boolean Integer`) are expanded in the
+		// document text fed to ANTLR. Without this, type-alias defines from included
+		// files cause false syntax errors (issue #133).
+		const includeDefines = await this.includeService.getIncludeDefines(uri);
+		const extraDefines = includeDefines
+			.filter(d => !d.defineParams?.length && d.value !== undefined && d.value !== '')
+			.map(d => ({ name: d.name, value: d.value! }));
+
+		// When include-file defines are present, re-parse the document with them
+		// so the expanded text is used for all validation. Fall back to the
+		// cached result when there are no extra defines to avoid the extra parse.
+		let parseResult = this.documentService.getParseResult(uri);
+		if (extraDefines.length > 0) {
+			const text = this.documentService.getText(uri);
+			if (text != null) {
+				parseResult = parse(text, extraDefines);
+			}
+		}
 		if (!parseResult) return [];
 
 		const diagnostics: Diagnostic[] = [];

--- a/server/src/services/formattingService.ts
+++ b/server/src/services/formattingService.ts
@@ -290,10 +290,7 @@ export function format12dplDocument(text: string, options: Format12dplOptions): 
 
 		// Compute indentation for the current line. Reduce indent for leading closing braces.
 		const leadingCloseCount = countLeadingChar(trimmed, '}');
-		let lineIndentLevel = indentLevel - leadingCloseCount;
-		if (trimmed.startsWith('case ') || trimmed.startsWith('default:')) {
-			lineIndentLevel = Math.max(0, lineIndentLevel - 1);
-		}
+		const lineIndentLevel = indentLevel - leadingCloseCount;
 
 		if (wasInBlockComment) {
 			// Preserve original content — block comment interior lines are not reindented.

--- a/tests/formatter.test.ts
+++ b/tests/formatter.test.ts
@@ -328,3 +328,51 @@ describe("format12dplDocument — indentStyle (spaces vs tabs)", () => {
 		expect(out).toContain("    Integer y;");
 	});
 });
+
+describe("format12dplDocument — switch/case indentation (#149)", () => {
+	const base = { insertSpaces: true, tabSize: 4 };
+
+	test("case label is indented one level inside switch braces", () => {
+		const input = "switch (myvar)\n{\ncase (123) :\n{\nbreak;\n}\n}\n";
+		const out = format12dplDocument(input, base);
+		const lines = out.split("\n");
+		expect(lines[2]).toBe("    case (123) :");
+	});
+
+	test("default: label is indented one level inside switch braces", () => {
+		const input = "switch (myvar)\n{\ndefault:\n{\nbreak;\n}\n}\n";
+		const out = format12dplDocument(input, base);
+		const lines = out.split("\n");
+		expect(lines[2]).toBe("    default:");
+	});
+
+	test("default : label (space before colon) is indented consistently with default:", () => {
+		const input = "switch (myvar)\n{\ndefault :\n{\nbreak;\n}\n}\n";
+		const out = format12dplDocument(input, base);
+		const lines = out.split("\n");
+		expect(lines[2]).toBe("    default :");
+	});
+
+	test("case and default are at the same indent level inside a switch", () => {
+		const input = [
+			"switch (myvar)",
+			"{",
+			"case (123) :",
+			"{",
+			"break;",
+			"}",
+			"default :",
+			"{",
+			"break;",
+			"}",
+			"}",
+			""
+		].join("\n");
+		const out = format12dplDocument(input, base);
+		const lines = out.split("\n");
+		const caseLine = lines.find(l => l.includes("case (123)"));
+		const defaultLine = lines.find(l => l.includes("default :"));
+		expect(caseLine).toBe("    case (123) :");
+		expect(defaultLine).toBe("    default :");
+	});
+});

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -2818,6 +2818,158 @@ void main()
 		const diagnostics = ValidateFunctionArgs(code, externalSigs);
 		expect(diagnostics.length).toBe(0);
 	});
+
+	// ─── Reference parameter receives temporary (issue #151) ─────────────────
+
+	test("warns when integer literal passed to reference parameter", () => {
+		const code = `
+void My_function(Real &x)
+{
+}
+
+void main()
+{
+	My_function(0);
+}
+`;
+		const diagnostics = ValidateFunctionArgs(code);
+		const warnings = diagnostics.filter(d => d.severity === 2 /* Warning */);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0].message).toContain("My_function");
+		expect(warnings[0].message).toContain("reference");
+		expect(warnings[0].message).toContain("temporary");
+	});
+
+	test("warns when real literal passed to reference parameter", () => {
+		const code = `
+void Set_value(Real &x)
+{
+}
+
+void main()
+{
+	Set_value(3.14);
+}
+`;
+		const diagnostics = ValidateFunctionArgs(code);
+		const warnings = diagnostics.filter(d => d.severity === 2 /* Warning */);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0].message).toContain("Set_value");
+		expect(warnings[0].message).toContain("temporary");
+	});
+
+	test("warns when string literal passed to reference parameter", () => {
+		const code = `
+void Set_name(Text &name)
+{
+}
+
+void main()
+{
+	Set_name("hello");
+}
+`;
+		const diagnostics = ValidateFunctionArgs(code);
+		const warnings = diagnostics.filter(d => d.severity === 2 /* Warning */);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0].message).toContain("Argument 1");
+		expect(warnings[0].message).toContain("temporary");
+	});
+
+	test("does not warn when variable passed to reference parameter", () => {
+		const code = `
+void My_function(Integer &x)
+{
+}
+
+void main()
+{
+	Integer val = 5;
+	My_function(val);
+}
+`;
+		const diagnostics = ValidateFunctionArgs(code);
+		const warnings = diagnostics.filter(d => d.severity === 2 /* Warning */);
+		expect(warnings.length).toBe(0);
+	});
+
+	test("warns only for the byRef argument, not all arguments", () => {
+		const code = `
+void Mixed(Integer a, Real &b, Text c)
+{
+}
+
+void main()
+{
+	Integer x = 1;
+	Text t = "hi";
+	Mixed(x, 0.5, t);
+}
+`;
+		const diagnostics = ValidateFunctionArgs(code);
+		const warnings = diagnostics.filter(d => d.severity === 2 /* Warning */);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0].message).toContain("Argument 2");
+	});
+
+	test("does not warn when a non-byRef overload also exists for that argument position", () => {
+		// foo(Real &x) and foo(Real x) — literal 0 should not warn because
+		// there is a non-byRef overload that accepts it.
+		const code = `
+void foo(Real &x)
+{
+}
+
+void foo(Real x)
+{
+}
+
+void main()
+{
+	foo(0);
+}
+`;
+		const diagnostics = ValidateFunctionArgs(code);
+		const warnings = diagnostics.filter(d => d.severity === 2 /* Warning */);
+		expect(warnings.length).toBe(0);
+	});
+
+	test("warns when multiple byRef parameters receive literals", () => {
+		const code = `
+void Swap(Integer &a, Integer &b)
+{
+}
+
+void main()
+{
+	Swap(1, 2);
+}
+`;
+		const diagnostics = ValidateFunctionArgs(code);
+		const warnings = diagnostics.filter(d => d.severity === 2 /* Warning */);
+		expect(warnings.length).toBe(2);
+		expect(warnings[0].message).toContain("Argument 1");
+		expect(warnings[1].message).toContain("Argument 2");
+	});
+
+	test("warns for reference parameter in external (include-file) function signatures", () => {
+		const externalSigs: FunctionSignatureMap = new Map();
+		externalSigs.set("Get_value", [
+			[{ name: "out", type: "Integer", byRef: true, isArray: false }]
+		]);
+
+		const code = `
+void main()
+{
+	Get_value(0);
+}
+`;
+		const diagnostics = ValidateFunctionArgs(code, externalSigs);
+		const warnings = diagnostics.filter(d => d.severity === 2 /* Warning */);
+		expect(warnings.length).toBe(1);
+		expect(warnings[0].message).toContain("Get_value");
+		expect(warnings[0].message).toContain("reference");
+	});
 });
 
 // ─── Return value validation (#47) ──────────────────────────────────────────

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { describe, expect, test } from "bun:test";
-import { parse, expandObjectLikeMacros } from "../server/src/core/parsePipeline";
+import { parse, expandObjectLikeMacros, stripConditionalDirectives } from "../server/src/core/parsePipeline";
 import { collectSymbolTable, deriveViews, parseDefines } from "../server/src/core/symbolCollector";
 import { validateVariableRedeclarations, validateFunctionRedeclarations, validateUndeclaredIdentifiers, validateDeprecatedCalls, validateVoidFunctionReturnValues, FunctionSignatureMap, validateFunctionArguments, validateReturnStatements, validateArraySize } from "../server/src/core/validators";
 import type { OverloadReturnType } from "../server/src/core/validators";
@@ -4258,6 +4258,75 @@ Number value = 3.14;
 `;
 		const result = parse(code);
 		expect(result.syntaxErrors.length).toBe(0);
+	});
+});
+
+// ─── #define type substitution from header files (issue #133) ────────────────
+//
+// When object-like type-alias defines are declared in a header file and not in
+// the current document, they must still be expanded before parsing. The
+// `parse()` function accepts an optional `extraDefines` parameter for this.
+
+describe("#define type substitution from included headers (issue #133)", () => {
+	test("type alias from header allows variable declaration without syntax error", () => {
+		// Simulates: test.h defines `#define Boolean Integer`, test.c includes it.
+		const code = `
+Integer Test(Text test) {
+    Boolean bool = 0;
+    return 0;
+}
+`;
+		const extraDefines = [{ name: 'Boolean', value: 'Integer' }];
+		const result = parse(code, extraDefines);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("constants from header allow use in expressions without syntax error", () => {
+		const code = `
+void main() {
+    Boolean active = FALSE;
+    Boolean done = TRUE;
+}
+`;
+		const extraDefines = [
+			{ name: 'Boolean', value: 'Integer' },
+			{ name: 'FALSE', value: '0' },
+			{ name: 'TRUE', value: '1' },
+		];
+		const result = parse(code, extraDefines);
+		expect(result.syntaxErrors.length).toBe(0);
+	});
+
+	test("expandObjectLikeMacros applies extraDefines from header not in rawText", () => {
+		// rawText has no #define — defines come from a header file.
+		const rawText = `Integer Test(Text test) {\n    Boolean flag = 0;\n    return 0;\n}\n`;
+		const { text: stripped } = stripConditionalDirectives(rawText);
+		const extraDefines = [{ name: 'Boolean', value: 'Integer' }];
+		const expanded = expandObjectLikeMacros(stripped, rawText, extraDefines);
+		expect(expanded).toContain('Integer flag = 0;');
+	});
+
+	test("local file defines take precedence over header extraDefines", () => {
+		// If the same name is defined locally, the local define wins.
+		const rawText = `#define Boolean Real\nBoolean x = 1;\n`;
+		const { text: stripped } = require('../server/src/core/parsePipeline').stripConditionalDirectives(rawText);
+		const extraDefines = [{ name: 'Boolean', value: 'Integer' }];
+		const expanded = expandObjectLikeMacros(stripped, rawText, extraDefines);
+		// Local `#define Boolean Real` should win — result is `Real`, not `Integer`.
+		expect(expanded).toContain('Real x = 1;');
+		expect(expanded).not.toContain('Integer x = 1;');
+	});
+
+	test("header type alias does not suppress unrelated syntax errors", () => {
+		const code = `
+void main() {
+    Boolean active = ;
+}
+`;
+		const extraDefines = [{ name: 'Boolean', value: 'Integer' }];
+		const result = parse(code, extraDefines);
+		// There is a real syntax error (missing value after `=`)
+		expect(result.syntaxErrors.length).toBeGreaterThan(0);
 	});
 });
 

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -1102,6 +1102,104 @@ void Test()
 	});
 });
 
+describe("Nested block scope isolation (issue #150)", () => {
+	test("reports error for variable used outside its declaring if-block", () => {
+		const code = `
+void My_function()
+{
+    if (1 == 1)
+    {
+        Model mymodel = Get_model("xyz");
+    }
+    Model_delete(mymodel);
+}
+`;
+		const knownSymbols = {
+			functions: new Set(['Get_model', 'Model_delete']),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d => d.severity === 1 && d.message.includes("is not declared"));
+		expect(errors.some(d => d.message.includes("mymodel"))).toBe(true);
+	});
+
+	test("does not flag a variable used inside its declaring if-block", () => {
+		const code = `
+void My_function()
+{
+    if (1 == 1)
+    {
+        Model mymodel = Get_model("xyz");
+        Model_delete(mymodel);
+    }
+}
+`;
+		const knownSymbols = {
+			functions: new Set(['Get_model', 'Model_delete']),
+			variables: new Set<string>(),
+			defines: new Set<string>()
+		};
+		const diagnostics = ValidateWithSymbols(code, knownSymbols);
+		const errors = diagnostics.filter(d => d.severity === 1 && d.message.includes("mymodel"));
+		expect(errors.length).toBe(0);
+	});
+
+	test("reports error for variable used after the if-else block that declares it", () => {
+		const code = `
+void test()
+{
+    if (1 == 1)
+    {
+        Integer x = 5;
+    }
+    else
+    {
+        Integer y = 10;
+    }
+    Integer z = x + y;
+}
+`;
+		const diagnostics = Validate(code);
+		const errors = diagnostics.filter(d => d.severity === 1 && d.message.includes("is not declared"));
+		expect(errors.some(d => d.message.includes("x"))).toBe(true);
+		expect(errors.some(d => d.message.includes("y"))).toBe(true);
+	});
+
+	test("variables declared before the if-block remain in scope after", () => {
+		const code = `
+void test()
+{
+    Integer x = 10;
+    if (x > 5)
+    {
+        Integer y = x + 1;
+    }
+    Integer z = x;
+}
+`;
+		const diagnostics = Validate(code);
+		const errors = diagnostics.filter(d => d.severity === 1 && d.message.includes("is not declared"));
+		expect(errors.length).toBe(0);
+	});
+
+	test("reports error for variable used outside its declaring while-block", () => {
+		const code = `
+void test()
+{
+    while (1 == 1)
+    {
+        Integer inner = 42;
+    }
+    Integer z = inner;
+}
+`;
+		const diagnostics = Validate(code);
+		const errors = diagnostics.filter(d => d.severity === 1 && d.message.includes("is not declared"));
+		expect(errors.some(d => d.message.includes("inner"))).toBe(true);
+	});
+});
+
 describe("KnownSymbols validation (PR #30 refactor)", () => {
 	// =========================================================================
 	// Known Functions Tests


### PR DESCRIPTION
### New Features
- **Temporary Value Warnings for Pass-by-Reference** (#151): A warning is now emitted when a literal or temporary value is passed to a `&` (pass-by-reference) parameter, since the callee cannot meaningfully write back to a temporary.
- **Block-Scope Variable Leak Detection** (#150): Variables declared inside a block (e.g. `if`, `for`) are no longer considered accessible outside that block. Using such a variable after its scope ends is now reported as an undeclared-symbol error.
- **Preprocessor Defines from Headers** (#155): The validation pipeline now performs a double parse so that `#define` statements from included header files are collected and substituted before the main validation pass, resolving false positives caused by macro-defined values from headers.

### Bug Fixes
- **Switch Statement Formatting**: Switch cases with compound bodies were indented incorrectly by the formatter; this has been corrected.