### PR TITLE
Fix enriched docs merging separate function entries (#125)

### DIFF
--- a/client/testFixture/enriched_doc_split.4dm
+++ b/client/testFixture/enriched_doc_split.4dm
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------
+// Regression fixture for issue #125 — "Documentation enrichment merges function
+// entries when manual ID footer is missing or malformed".
+//
+// The enrichment process used the manual's "ID = <number>" footer as the entry
+// boundary. When that footer was malformed (e.g. "D = 879") or missing, the next
+// function's manual block was swallowed into the previous function's description,
+// so functions such as Set_focus lost their own documentation.
+//
+// HOW TO USE THIS FILE:
+//   Hover over each library call below. Every function should show its OWN
+//   description (the "hover ->" comment states what you should see). None of the
+//   host functions (Get_id, Get_name, ...) should leak the following function's
+//   text into their hover any more.
+//
+// This file is also a syntax/validation smoke test: it must produce ZERO
+// diagnostics from the language server (every call uses a real overload).
+// ---------------------------------------------------------------------------
+
+void main()
+{
+	Integer result;
+
+	// --- Widget handles -----------------------------------------------------
+	Widget w;
+
+	// hover -> Get_id(Widget): "When a Widget is created, it is given a unique
+	// identifying number (id) ..." and must NO LONGER contain the Set_focus text.
+	result = Get_id(w);
+
+	// hover -> Set_focus: "Set the focus to the typed input area for an Input
+	// Widget widget, or on the button for a Button Widget widget. ..."
+	// (was previously buried inside Get_id, with no standalone entry).
+	result = Set_focus(w);
+
+	// --- Tin handles --------------------------------------------------------
+	Tin tin;
+	Text tin_name;
+	Dynamic_Text model_names;
+
+	// hover -> Get_name(Tin, Text): "Get the name of the Tin tin. ..." and must
+	// NO LONGER contain the Tin_models text.
+	result = Get_name(tin, tin_name);
+
+	// hover -> Tin_models: "Get the names of all the models that were used to
+	// create the Tin tin. ..." (recovered standalone entry).
+	result = Tin_models(tin, model_names);
+
+	// --- Pipe / 3d string data (array + indexed overloads) ------------------
+	Element elt;
+	Real x[100], y[100], z[100];
+	Integer num_pts = 100;
+	Integer max_pts = 100;
+	Integer offset = 1;
+	Integer i = 1;
+	Real xi, yi, zi;
+
+	// hover -> Get_3d_data(Element, Real[], Real[], Real[], Integer, Integer,
+	// Integer): the start_pt chunked overload (recovered standalone entry).
+	result = Get_3d_data(elt, x, y, z, max_pts, num_pts, offset);
+
+	// hover -> Get_3d_data(Element, Integer, Real, Real, Real): "Get the (x,y,z)
+	// data for the ith point of the string. ..." (recovered standalone entry).
+	result = Get_3d_data(elt, i, xi, yi, zi);
+
+	// hover -> Set_3d_data(Element, Integer, Real, Real, Real): "Set the (x,y,z)
+	// data for the ith point of the string. ..." (replaced a placeholder).
+	result = Set_3d_data(elt, i, xi, yi, zi);
+
+	// hover -> Set_pipe_data(Element, Real[], Real[], Real[], Integer): the
+	// first-num_pts overload (recovered — Set_pipe_data had no entries at all).
+	result = Set_pipe_data(elt, x, y, z, num_pts);
+
+	// hover -> Set_pipe_data(Element, Real[], Real[], Real[], Integer, Integer):
+	// the start_pt chunked overload (recovered standalone entry).
+	result = Set_pipe_data(elt, x, y, z, num_pts, offset);
+
+	// hover -> Set_pipe_data(Element, Integer, Real, Real, Real): the ith-point
+	// overload (recovered standalone entry).
+	result = Set_pipe_data(elt, i, xi, yi, zi);
+
+	// hover -> Get_pipe_data(Element, Integer, Real, Real, Real): "Get the
+	// (x,y,z) data for the ith point of the string. ..." (recovered overload).
+	result = Get_pipe_data(elt, i, xi, yi, zi);
+
+	// --- Select_Button widgets ----------------------------------------------
+	Select_Button btn;
+	Real sx, sy, sz, sch, sht;
+
+	// hover -> Get_select_coordinate(Select_Button, Real, Real, Real, Real,
+	// Real): "Get the coordinate of the selected snap point. ..." (the #1047
+	// overload that was swallowed into Set_select_snap_mode).
+	result = Get_select_coordinate(btn, sx, sy, sz, sch, sht);
+
+	// --- Drape (4-argument overload) ----------------------------------------
+	Dynamic_Element source_strings;
+	Dynamic_Element draped_strings;
+	Integer create_supers = 1;
+
+	// hover -> Drape(Tin, Dynamic_Element, Dynamic_Element, Integer): "... The
+	// resulting elements in draped_elts will be super string only if
+	// create_supers is non zero. ..." (recovered #3790 overload).
+	result = Drape(tin, source_strings, draped_strings, create_supers);
+
+	// --- Split_string -------------------------------------------------------
+	Element source_string, string1, string2;
+	Real chainage = 100.0;
+
+	// hover -> Split_string(Element, Real, Element, Element): "Split a string
+	// about a chainage ..." (recovered — was swallowed into Polygons_clip).
+	result = Split_string(source_string, chainage, string1, string2);
+
+	return;
+}

--- a/scripts/split-merged-enriched.ts
+++ b/scripts/split-merged-enriched.ts
@@ -1,0 +1,282 @@
+/**
+ * split-merged-enriched.ts — repair merged entries in functions.enriched.json.
+ *
+ * Background (see issue #125):
+ * The manual-extraction process that produced functions.enriched.json used the
+ * `ID = <number>` footer as the primary function-entry boundary. When that footer
+ * is malformed (e.g. `D = 879` instead of `ID = 879`) or missing, the following
+ * function's manual block is swallowed into the previous function's description.
+ *
+ * This script re-splits descriptions on the manual heading structure, which is a
+ * far more reliable boundary than the ID footer:
+ *
+ *     Function_name(<params>) Name <ReturnType> Function_name(<params>) Description <body...>
+ *
+ * The double-mention of the function name around `Name`/`Description` is the
+ * signature of a manual entry heading. For every enriched entry that has such a
+ * block embedded inside its description:
+ *   - the text before the first embedded heading stays with the host entry;
+ *   - each embedded heading becomes its own standalone entry, matched to its
+ *     compiler overload by name + parameter types, and its body is recovered;
+ *   - a swallowed function that already has a real enriched entry is dropped;
+ *   - a swallowed function whose existing entry is only a placeholder
+ *     ("12dPL function X") has that placeholder replaced with the recovered body;
+ *   - a host left with no real description (only an ID footer / page header) gets
+ *     a neutral "12dPL function X" placeholder rather than the wrong, swallowed text.
+ *
+ * Run `bun scripts/split-merged-enriched.ts` for a dry run (no writes),
+ * or `bun scripts/split-merged-enriched.ts --write` to update the resource file.
+ */
+import * as fs from "fs";
+import * as path from "path";
+
+interface FunctionParam { name: string; type: string; }
+interface FunctionEntry {
+	name: string;
+	id: number;
+	returnType: string;
+	parameters: FunctionParam[];
+	description: string;
+}
+
+const WRITE = process.argv.includes("--write");
+const resourcesDir = path.resolve(__dirname, "..", "server", "src", "resources");
+const compilerPath = path.join(resourcesDir, "functions.compiler.json");
+const enrichedPath = path.join(resourcesDir, "functions.enriched.json");
+
+const compiler: FunctionEntry[] = JSON.parse(fs.readFileSync(compilerPath, "utf-8"));
+const enriched: FunctionEntry[] = JSON.parse(fs.readFileSync(enrichedPath, "utf-8"));
+
+const compilerNames = new Set(compiler.map((f) => f.name));
+const compilerByName = new Map<string, FunctionEntry[]>();
+for (const fn of compiler) {
+	const key = fn.name.toLowerCase();
+	const list = compilerByName.get(key);
+	if (list) list.push(fn);
+	else compilerByName.set(key, [fn]);
+}
+
+// Page-header / footer artifacts left behind by the PDF extraction.
+const NOISE_PATTERNS: RegExp[] = [
+	/Strings Replaced by Super Strings Page \d+ 12d Model Macro Manual/g,
+	/Page \d+ Strings Replaced by Super Strings Chapter 5 12dPL Library Calls/g,
+	/Panels and Widgets Page \d+ 12d Model Macro Manual/g,
+	/Project Setting Page \d+ 12d Model Macro Manual/g,
+	/General Page \d+ 12d Model Macro Manual/g,
+	/Page \d+ 12d Model Macro Manual/g,
+	// "ID = 879" / malformed "D = 879" footers that leaked into the text.
+	/\b[I]?D = \d+\b/g,
+];
+
+function stripNoise(text: string): string {
+	let out = text;
+	for (const re of NOISE_PATTERNS) out = out.replace(re, " ");
+	return out.replace(/\s+/g, " ").trim();
+}
+
+function isPlaceholder(desc: string): boolean {
+	return /^\s*12dPL function /i.test(desc);
+}
+
+function isSubstantive(desc: string): boolean {
+	if (isPlaceholder(desc)) return false;
+	const cleaned = stripNoise(desc);
+	return cleaned.length >= 20 && /\s/.test(cleaned);
+}
+
+function placeholderFor(name: string): string {
+	return `12dPL function ${name}`;
+}
+
+function normalizeType(type: string): string {
+	// eslint-disable-next-line no-control-regex
+	return type.replace(/[^\x20-\x7E]/g, "").trim().toLowerCase();
+}
+
+function sigOf(params: FunctionParam[]): string {
+	return params.map((p) => normalizeType(p.type)).join(",");
+}
+
+// Parameter types as written in a manual heading, e.g.
+// "Element elt,Real x[],Integer &num_pts" -> ["element", "real", "integer"].
+function headingSig(rawParams: string): string {
+	const trimmed = rawParams.trim();
+	if (trimmed === "") return "";
+	return trimmed
+		.split(",")
+		.map((p) => p.trim().split(/\s+/)[0].replace(/[^A-Za-z0-9_].*$/, "").toLowerCase())
+		.filter((t) => t.length > 0)
+		.join(",");
+}
+
+// Manual-heading block: "Fn(<params>) Name <ReturnType> Fn(<params>) Description".
+const BLOCK_RE = /([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s+Name\s+([A-Za-z_][A-Za-z0-9_]*)\s+\1\s*\(([^)]*)\)\s+Description\b/g;
+
+interface Block { name: string; sig: string; start: number; headerEnd: number; }
+
+function findBlocks(desc: string): Block[] {
+	const blocks: Block[] = [];
+	BLOCK_RE.lastIndex = 0;
+	let m: RegExpExecArray | null;
+	while ((m = BLOCK_RE.exec(desc)) !== null) {
+		const name = m[1];
+		if (!compilerNames.has(name)) continue; // only treat compiler-known headings as boundaries
+		blocks.push({
+			name,
+			sig: headingSig(m[2]),
+			start: m.index,
+			headerEnd: m.index + m[0].length,
+		});
+	}
+	return blocks;
+}
+
+// Index existing enriched entries by name|sig so we can decide create vs. replace vs. drop.
+const enrichedByKey = new Map<string, FunctionEntry[]>();
+for (const fn of enriched) {
+	const key = `${fn.name.toLowerCase()}|${sigOf(fn.parameters)}`;
+	const list = enrichedByKey.get(key);
+	if (list) list.push(fn);
+	else enrichedByKey.set(key, [fn]);
+}
+
+function matchCompilerOverload(name: string, sig: string): FunctionEntry | null {
+	const overloads = compilerByName.get(name.toLowerCase());
+	if (!overloads) return null;
+	const exact = overloads.find((c) => sigOf(c.parameters) === sig);
+	return exact ?? null;
+}
+
+const stats = {
+	hosts_processed: 0,
+	hosts_trimmed: 0,
+	hosts_placeholdered: 0,
+	created: 0,
+	replaced_placeholder: 0,
+	dropped_existing: 0,
+	dropped_self: 0,
+	skipped_empty_body: 0,
+};
+const replacements = new Map<string, string>(); // name|sig -> recovered description
+const createdKeys = new Set<string>();
+const insertAfter = new Map<FunctionEntry, FunctionEntry[]>(); // host -> new entries
+
+for (const host of enriched) {
+	const blocks = findBlocks(host.description);
+	const hostKey = `${host.name.toLowerCase()}|${sigOf(host.parameters)}`;
+	// Only repair genuine cross-entry merges: an embedded heading for a *different*
+	// overload (different name or signature). A heading for the host's own overload
+	// is a self-restatement, not a swallowed entry, and is left alone — this matches
+	// the regression test in tests/enrichedFunctions.test.ts.
+	const hasDifferentOverload = blocks.some(
+		(b) => `${b.name.toLowerCase()}|${b.sig}` !== hostKey
+	);
+	if (!hasDifferentOverload) continue;
+
+	stats.hosts_processed++;
+	const newEntries: FunctionEntry[] = [];
+
+	for (let i = 0; i < blocks.length; i++) {
+		const block = blocks[i];
+		const bodyEnd = i + 1 < blocks.length ? blocks[i + 1].start : host.description.length;
+		const body = stripNoise(host.description.slice(block.headerEnd, bodyEnd));
+		const overload = matchCompilerOverload(block.name, block.sig);
+		if (!overload) {
+			console.warn(`  ! no compiler overload for ${block.name}(${block.sig}) — left in place`);
+			continue;
+		}
+		const key = `${overload.name.toLowerCase()}|${sigOf(overload.parameters)}`;
+
+		// A heading for the host's own overload: the host already represents it, so
+		// the restated body is redundant — drop it rather than creating a duplicate.
+		if (key === hostKey) {
+			stats.dropped_self++;
+			console.log(`  drop ${overload.name}(${block.sig}) — host's own overload`);
+			continue;
+		}
+
+		const existing = enrichedByKey.get(key) ?? [];
+		const hasReal = existing.some((e) => e !== host && isSubstantive(e.description));
+
+		if (hasReal) {
+			stats.dropped_existing++;
+			console.log(`  drop ${overload.name}(${block.sig}) — already documented`);
+			continue;
+		}
+		if (!isSubstantive(body)) {
+			stats.skipped_empty_body++;
+			console.log(`  skip ${overload.name}(${block.sig}) — no recoverable body`);
+			continue;
+		}
+		const placeholderEntry = existing.find((e) => e !== host && isPlaceholder(e.description));
+		if (placeholderEntry) {
+			replacements.set(key, body);
+			stats.replaced_placeholder++;
+			console.log(`  replace placeholder ${overload.name}(${block.sig})`);
+			continue;
+		}
+		if (createdKeys.has(key)) {
+			console.log(`  drop ${overload.name}(${block.sig}) — already recreated`);
+			continue;
+		}
+		createdKeys.add(key);
+		newEntries.push({
+			name: overload.name,
+			id: overload.id,
+			returnType: overload.returnType,
+			parameters: overload.parameters.map((p) => ({ name: p.name, type: p.type })),
+			description: body,
+		});
+		stats.created++;
+		console.log(`  create ${overload.name}(${block.sig}) — ${body.length} chars`);
+	}
+
+	// Host keeps only the text before the first embedded heading.
+	const hostBody = stripNoise(host.description.slice(0, blocks[0].start));
+	if (isSubstantive(hostBody)) {
+		host.description = hostBody;
+		stats.hosts_trimmed++;
+		console.log(`HOST ${host.name}(${sigOf(host.parameters)}) — trimmed to ${hostBody.length} chars`);
+	} else {
+		host.description = placeholderFor(host.name);
+		stats.hosts_placeholdered++;
+		console.log(`HOST ${host.name}(${sigOf(host.parameters)}) — no recoverable description, placeholdered`);
+	}
+
+	if (newEntries.length > 0) insertAfter.set(host, newEntries);
+}
+
+// Apply placeholder replacements to existing entries.
+for (const fn of enriched) {
+	const key = `${fn.name.toLowerCase()}|${sigOf(fn.parameters)}`;
+	const repl = replacements.get(key);
+	if (repl && isPlaceholder(fn.description)) {
+		fn.description = repl;
+	}
+}
+
+// Rebuild the array, inserting recovered entries right after their host.
+const result: FunctionEntry[] = [];
+for (const fn of enriched) {
+	result.push(fn);
+	const extras = insertAfter.get(fn);
+	if (extras) result.push(...extras);
+}
+
+console.log("\n=== Summary ===");
+console.log(`  Hosts processed:          ${stats.hosts_processed}`);
+console.log(`  Hosts trimmed:            ${stats.hosts_trimmed}`);
+console.log(`  Hosts placeholdered:      ${stats.hosts_placeholdered}`);
+console.log(`  New standalone entries:   ${stats.created}`);
+console.log(`  Placeholders replaced:    ${stats.replaced_placeholder}`);
+console.log(`  Dropped (already doc'd):  ${stats.dropped_existing}`);
+console.log(`  Dropped (host's own):     ${stats.dropped_self}`);
+console.log(`  Skipped (no body):        ${stats.skipped_empty_body}`);
+console.log(`  Entries: ${enriched.length} -> ${result.length}`);
+
+if (WRITE) {
+	fs.writeFileSync(enrichedPath, JSON.stringify(result, null, 2) + "\n", "utf-8");
+	console.log(`\n✅ Wrote ${enrichedPath}`);
+} else {
+	console.log(`\n(dry run — pass --write to update ${path.relative(process.cwd(), enrichedPath)})`);
+}

--- a/server/src/resources/functions.enriched.json
+++ b/server/src/resources/functions.enriched.json
@@ -3235,7 +3235,7 @@
         "type": "Integer"
       }
     ],
-    "description": "This function basically calls the Microsoft CreateProcess function as defined in http://msdn.microsoft.com/en-us/library/ms682425%28v=vs.85%29.aspx. The 12d function gives access to the Microsoft CreateProcess arguments that are in bold (and also do not have a // in front of them): BOOL WINAPI CreateProcess( __in_opt LPCTSTR lpApplicationName, __inout_opt LPTSTR lpCommandLine, // __in_opt LPSECURITY_ATTRIBUTES lpProcessAttributes, // __in_opt LPSECURITY_ATTRIBUTES lpThreadAttributes, __in BOOL bInheritHandles, __in DWORD dwCreationFlags, // __in_opt LPVOID lpEnvironment, __in_opt LPCTSTR lpCurrentDirectory, // __in LPSTARTUPINFO lpStartupInfo, System Page 155 12d Model Macro Manual // __out LPPROCESS_INFORMATION lpProcessInformation ); where program_name is passed as lpApplicationName, command_line is passed as dwCreationFlags lpCommandLine, start_directory is passed as lpCurrentDirectory, flags is passed as dwCreationFlags and inherit is passed as bInheritHandles. If wait = 1, the macro will wait until the process finishes before continuing. If wait = 0, the macro won\u2019t wait until the process finishes before continuing. A function return value of zero indicates the function was successful. Note: Create_process can not be called from the 12d Model Practise version."
+    "description": "This function basically calls the Microsoft CreateProcess function as defined in http://msdn.microsoft.com/en-us/library/ms682425%28v=vs.85%29.aspx. The 12d function gives access to the Microsoft CreateProcess arguments that are in bold (and also do not have a // in front of them): BOOL WINAPI CreateProcess( __in_opt LPCTSTR lpApplicationName, __inout_opt LPTSTR lpCommandLine, // __in_opt LPSECURITY_ATTRIBUTES lpProcessAttributes, // __in_opt LPSECURITY_ATTRIBUTES lpThreadAttributes, __in BOOL bInheritHandles, __in DWORD dwCreationFlags, // __in_opt LPVOID lpEnvironment, __in_opt LPCTSTR lpCurrentDirectory, // __in LPSTARTUPINFO lpStartupInfo, System Page 155 12d Model Macro Manual // __out LPPROCESS_INFORMATION lpProcessInformation ); where program_name is passed as lpApplicationName, command_line is passed as dwCreationFlags lpCommandLine, start_directory is passed as lpCurrentDirectory, flags is passed as dwCreationFlags and inherit is passed as bInheritHandles. If wait = 1, the macro will wait until the process finishes before continuing. If wait = 0, the macro won’t wait until the process finishes before continuing. A function return value of zero indicates the function was successful. Note: Create_process can not be called from the 12d Model Practise version."
   },
   {
     "name": "Create_process",
@@ -14855,7 +14855,23 @@
         "type": "Text"
       }
     ],
-    "description": "Get the name of the Tin tin. The tin name is returned in the Text tin_name. A function return value of zero indicates success. If tin is null, the function return value is non-zero. Tin_models(Tin tin, Dynamic_Text &models_used) Name Integer Tin_models(Tin tin, Dynamic_Text &models_used) Description Get the names of all the models that were used to create the Tin tin. The model names are returned in the Dynamic_Text models_used. A function return value of zero indicates that the view names were returned successfully."
+    "description": "Get the name of the Tin tin. The tin name is returned in the Text tin_name. A function return value of zero indicates success. If tin is null, the function return value is non-zero."
+  },
+  {
+    "name": "Tin_models",
+    "id": 431,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "tin",
+        "type": "Tin"
+      },
+      {
+        "name": "models",
+        "type": "Dynamic_Text"
+      }
+    ],
+    "description": "Get the names of all the models that were used to create the Tin tin. The model names are returned in the Dynamic_Text models_used. A function return value of zero indicates that the view names were returned successfully."
   },
   {
     "name": "Get_time_updated",
@@ -39770,7 +39786,71 @@
         "type": "Integer"
       }
     ],
-    "description": "Get the (x,y,z) data for the first max_pts points of the 3d Element elt. The (x,y,z) values at each string point are returned in the Real arrays x[], y[] and z[]. The maximum number of points that can be returned is given by max_pts (usually the size of the arrays). The point data returned starts at the first point and goes up to the minimum of max_pts and the number of points in the string. The actual number of points returned is returned by Integer num_pts num_pts <= max_pts If the Element elt is not of type 3d, then num_pts is returned as zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned. Get_3d_data(Element elt,Real x[],Real y[],Real z[],Integer max_pts,Integer &num_pts,Integer start_pt) Name Integer Get_3d_data(Element elt,Real x[],Real y[],Real z[],Integer max_pts,Integer &num_pts,Integer start_pt) Description For a 3d Element elt, get the (x,y,z) data for max_pts points starting at point number start_pt. This routine allows the user to return the data from a 3d string in user specified chunks. This is necessary if the number of points in the string is greater than the size of the arrays available to contain the information. As in the previous function, the maximum number of points that can be returned is given by max_pts (usually the size of the arrays). However, for this function, the point data returned starts at point number start_pt rather than point one. The (x,y,z) values at each string point are returned in the Real arrays x[], y[] and z[]. The actual number of points returned is given by Integer num_pts num_pts <= max_pts If the Element elt is not of type 3d, then num_pts is set to zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned. Note Strings Replaced by Super Strings Page 847 12d Model Macro Manual A start_pt of one gives the same result as for the previous function. Get_3d_data(Element elt,Integer i, Real &x,Real &y,Real &z) Name Integer Get_3d_data(Element elt,Integer i, Real &x,Real &y,Real &z) Description Get the (x,y,z) data for the ith point of the string. The x value is returned in Real x. The y value is returned in Real y. The z value is returned in Real z. A function return value of zero indicates the data was successfully returned. Set_3d_data(Element elt,Real x[],Real y[],Real z[],Integer num_pts) Name Integer Set_3d_data(Element elt,Real x[],Real y[],Real z[],Integer num_pts) Description Set the (x,y,z) data for the first num_pts points of the 3d Element elt. This function allows the user to modify a large number of points of the string in one call. The maximum number of points that can be set is given by the number of points in the string. The (x,y,z) values for each string point are given in the Real arrays x[], y[] and z[]. The number of points to be set is given by Integer num_pts If the Element elt is not of type 3d, then nothing is modified and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully set. Note This function can not create new 3d Elements but only modify existing 3d Elements."
+    "description": "Get the (x,y,z) data for the first max_pts points of the 3d Element elt. The (x,y,z) values at each string point are returned in the Real arrays x[], y[] and z[]. The maximum number of points that can be returned is given by max_pts (usually the size of the arrays). The point data returned starts at the first point and goes up to the minimum of max_pts and the number of points in the string. The actual number of points returned is returned by Integer num_pts num_pts <= max_pts If the Element elt is not of type 3d, then num_pts is returned as zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned."
+  },
+  {
+    "name": "Get_3d_data",
+    "id": 79,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "element",
+        "type": "Element"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      },
+      {
+        "name": "max_pts",
+        "type": "Integer"
+      },
+      {
+        "name": "num_pts",
+        "type": "Integer"
+      },
+      {
+        "name": "offset",
+        "type": "Integer"
+      }
+    ],
+    "description": "For a 3d Element elt, get the (x,y,z) data for max_pts points starting at point number start_pt. This routine allows the user to return the data from a 3d string in user specified chunks. This is necessary if the number of points in the string is greater than the size of the arrays available to contain the information. As in the previous function, the maximum number of points that can be returned is given by max_pts (usually the size of the arrays). However, for this function, the point data returned starts at point number start_pt rather than point one. The (x,y,z) values at each string point are returned in the Real arrays x[], y[] and z[]. The actual number of points returned is given by Integer num_pts num_pts <= max_pts If the Element elt is not of type 3d, then num_pts is set to zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned. Note A start_pt of one gives the same result as for the previous function."
+  },
+  {
+    "name": "Get_3d_data",
+    "id": 82,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "element",
+        "type": "Element"
+      },
+      {
+        "name": "i",
+        "type": "Integer"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      }
+    ],
+    "description": "Get the (x,y,z) data for the ith point of the string. The x value is returned in Real x. The y value is returned in Real y. The z value is returned in Real z. A function return value of zero indicates the data was successfully returned."
   },
   {
     "name": "Set_3d_data",
@@ -39798,7 +39878,7 @@
         "type": "Integer"
       }
     ],
-    "description": "12dPL function Set_3d_data"
+    "description": "Set the (x,y,z) data for the first num_pts points of the 3d Element elt. This function allows the user to modify a large number of points of the string in one call. The maximum number of points that can be set is given by the number of points in the string. The (x,y,z) values for each string point are given in the Real arrays x[], y[] and z[]. The number of points to be set is given by Integer num_pts If the Element elt is not of type 3d, then nothing is modified and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully set. Note This function can not create new 3d Elements but only modify existing 3d Elements."
   },
   {
     "name": "Set_3d_data",
@@ -39830,7 +39910,35 @@
         "type": "Integer"
       }
     ],
-    "description": "For the 3d Element elt, set the (x,y,z) data for num_pts points, starting at point number start_pt. This function allows the user to modify a large number of points of the string in one call starting at point number start_pt rather than point one. The maximum number of points that can be set is given by the difference between the number of points in the string and the value of start_pt. The (x,y,z) values for the string points are given in the Real arrays x[], y[] and z[]. The number of the first string point to be modified is start_pt. The total number of points to be set is given by Integer num_pts If the Element elt is not of type 3d, then nothing is modified and the function return value is set to a Page 848 Strings Replaced by Super Strings Chapter 5 12dPL Library Calls non- zero value. A function return value of zero indicates the data was successfully set. Notes (a) A start_pt of one gives the same result as the previous function. (b) This function can not create new 3d Elements but only modify existing 3d Elements. Set_3d_data(Element elt,Integer i,Real x,Real y,Real z) Name Integer Set_3d_data(Element elt,Integer i,Real x,Real y,Real z) Description Set the (x,y,z) data for the ith point of the string. The x value is given in Real x. The y value is given in Real y. The z value is given in Real z. A function return value of zero indicates the data was successfully set."
+    "description": "For the 3d Element elt, set the (x,y,z) data for num_pts points, starting at point number start_pt. This function allows the user to modify a large number of points of the string in one call starting at point number start_pt rather than point one. The maximum number of points that can be set is given by the difference between the number of points in the string and the value of start_pt. The (x,y,z) values for the string points are given in the Real arrays x[], y[] and z[]. The number of the first string point to be modified is start_pt. The total number of points to be set is given by Integer num_pts If the Element elt is not of type 3d, then nothing is modified and the function return value is set to a non- zero value. A function return value of zero indicates the data was successfully set. Notes (a) A start_pt of one gives the same result as the previous function. (b) This function can not create new 3d Elements but only modify existing 3d Elements."
+  },
+  {
+    "name": "Set_3d_data",
+    "id": 83,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "element",
+        "type": "Element"
+      },
+      {
+        "name": "i",
+        "type": "Integer"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      }
+    ],
+    "description": "Set the (x,y,z) data for the ith point of the string. The x value is given in Real x. The y value is given in Real y. The z value is given in Real z. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Create_4d",
@@ -40794,7 +40902,35 @@
         "type": "Integer"
       }
     ],
-    "description": "Page 866 Strings Replaced by Super Strings Chapter 5 12dPL Library Calls Get the (x,y,z) data for the first max_pts points of the pipe Element elt. The (x,y,z) values at each string point are returned in the Real arrays x[], y[] and z[]. The maximum number of points that can be returned is given by max_pts (usually the size of the arrays). The point data returned starts at the first point and goes up to the minimum of max_pts and the number of points in the string. The actual number of points returned is returned by Integer num_pts num_pts <= max_pts If the Element elt is not of type pipe, then num_pts is returned as zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned. Set_pipe_data(Element elt,Real x[],Real y[],Real z[],Integer num_pts) Name Integer Set_pipe_data(Element elt,Real x[],Real y[],Real z[],Integer num_pts) Description Set the (x,y,z) data for the first num_pts points of the pipe Element elt. This function allows the user to modify a large number of points of the string in one call. The maximum number of points that can be set is given by the number of points in the string. The (x,y,z) values for each string point are given in the Real arrays x[], y[] and z[]. The number of points to be set is given by Integer num_pts If the Element elt is not of type pipe, then nothing is modified and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully set. Note This function can not create new pipe Elements but only modify existing pipe Elements."
+    "description": "Get the (x,y,z) data for the first max_pts points of the pipe Element elt. The (x,y,z) values at each string point are returned in the Real arrays x[], y[] and z[]. The maximum number of points that can be returned is given by max_pts (usually the size of the arrays). The point data returned starts at the first point and goes up to the minimum of max_pts and the number of points in the string. The actual number of points returned is returned by Integer num_pts num_pts <= max_pts If the Element elt is not of type pipe, then num_pts is returned as zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned."
+  },
+  {
+    "name": "Set_pipe_data",
+    "id": 80,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "element",
+        "type": "Element"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      },
+      {
+        "name": "num_pts",
+        "type": "Integer"
+      }
+    ],
+    "description": "Set the (x,y,z) data for the first num_pts points of the pipe Element elt. This function allows the user to modify a large number of points of the string in one call. The maximum number of points that can be set is given by the number of points in the string. The (x,y,z) values for each string point are given in the Real arrays x[], y[] and z[]. The number of points to be set is given by Integer num_pts If the Element elt is not of type pipe, then nothing is modified and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully set. Note This function can not create new pipe Elements but only modify existing pipe Elements."
   },
   {
     "name": "Get_pipe_data",
@@ -40830,7 +40966,95 @@
         "type": "Integer"
       }
     ],
-    "description": "For a pipe Element elt, get the (x,y,z) data for max_pts points starting at point number start_pt. This routine allows the user to return the data from a pipe string in user specified chunks. This is necessary if the number of points in the string is greater than the size of the arrays available to contain the information. As in the previous function, the maximum number of points that can be returned is given by max_pts (usually the size of the arrays). However, for this function, the point data returned starts at point number start_pt rather than point one. The (x,y,z) values at each string point are returned in the Real arrays x[], y[] and z[]. The actual number of points returned is given by Integer num_pts Strings Replaced by Super Strings Page 867 12d Model Macro Manual num_pts <= max_pts If the Element elt is not of type pipe, then num_pts is set to zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned. Note A start_pt of one gives the same result as for the previous function. Set_pipe_data(Element elt,Real x[],Real y[],Real z[],Integer num_pts,Integer start_pt) Name Integer Set_pipe_data(Element elt,Real x[],Real y[],Real z[],Integer num_pts,Integer start_pt) Description For the pipe Element elt, set the (x,y,z) data for num_pts points, starting at point number start_pt. This function allows the user to modify a large number of points of the string in one call starting at point number start_pt rather than point one. The maximum number of points that can be set is given by the difference between the number of points in the string and the value of start_pt. The (x,y,z) values for the string points are given in the Real arrays x[], y[] and z[]. The number of the first string point to be modified is start_pt. The total number of points to be set is given by Integer num_pts If the Element elt is not of type pipe, then nothing is modified and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully set. Notes (a) A start_pt of one gives the same result as the previous function. (b) This function can not create new pipe Elements but only modify existing pipe Elements. Get_pipe_data(Element elt,Integer i, Real &x,Real &y,Real &z) Name Integer Get_pipe_data(Element elt,Integer i, Real &x,Real &y,Real &z) Description Get the (x,y,z) data for the ith point of the string. The x value is returned in Real x. The y value is returned in Real y. The z value is returned in Real z. A function return value of zero indicates the data was successfully returned. Set_pipe_data(Element elt,Integer i,Real x,Real y,Real z) Name Integer Set_pipe_data(Element elt,Integer i,Real x,Real y,Real z) Description Set the (x,y,z) data for the ith point of the string. Page 868 Strings Replaced by Super Strings Chapter 5 12dPL Library Calls The x value is given in Real x. The y value is given in Real y. The z value is given in Real z. A function return value of zero indicates the data was successfully set."
+    "description": "For a pipe Element elt, get the (x,y,z) data for max_pts points starting at point number start_pt. This routine allows the user to return the data from a pipe string in user specified chunks. This is necessary if the number of points in the string is greater than the size of the arrays available to contain the information. As in the previous function, the maximum number of points that can be returned is given by max_pts (usually the size of the arrays). However, for this function, the point data returned starts at point number start_pt rather than point one. The (x,y,z) values at each string point are returned in the Real arrays x[], y[] and z[]. The actual number of points returned is given by Integer num_pts num_pts <= max_pts If the Element elt is not of type pipe, then num_pts is set to zero and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully returned. Note A start_pt of one gives the same result as for the previous function."
+  },
+  {
+    "name": "Set_pipe_data",
+    "id": 81,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "element",
+        "type": "Element"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      },
+      {
+        "name": "num_pts",
+        "type": "Integer"
+      },
+      {
+        "name": "offset",
+        "type": "Integer"
+      }
+    ],
+    "description": "For the pipe Element elt, set the (x,y,z) data for num_pts points, starting at point number start_pt. This function allows the user to modify a large number of points of the string in one call starting at point number start_pt rather than point one. The maximum number of points that can be set is given by the difference between the number of points in the string and the value of start_pt. The (x,y,z) values for the string points are given in the Real arrays x[], y[] and z[]. The number of the first string point to be modified is start_pt. The total number of points to be set is given by Integer num_pts If the Element elt is not of type pipe, then nothing is modified and the function return value is set to a non-zero value. A function return value of zero indicates the data was successfully set. Notes (a) A start_pt of one gives the same result as the previous function. (b) This function can not create new pipe Elements but only modify existing pipe Elements."
+  },
+  {
+    "name": "Get_pipe_data",
+    "id": 82,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "element",
+        "type": "Element"
+      },
+      {
+        "name": "i",
+        "type": "Integer"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      }
+    ],
+    "description": "Get the (x,y,z) data for the ith point of the string. The x value is returned in Real x. The y value is returned in Real y. The z value is returned in Real z. A function return value of zero indicates the data was successfully returned."
+  },
+  {
+    "name": "Set_pipe_data",
+    "id": 83,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "element",
+        "type": "Element"
+      },
+      {
+        "name": "i",
+        "type": "Integer"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      }
+    ],
+    "description": "Set the (x,y,z) data for the ith point of the string. The x value is given in Real x. The y value is given in Real y. The z value is given in Real z. A function return value of zero indicates the data was successfully set."
   },
   {
     "name": "Get_pipe_diameter",
@@ -43596,7 +43820,7 @@
         "type": "Text"
       }
     ],
-    "description": "ID = 3547 Get_project_setting_real(Text name) Name Real Get_project_setting_real(Text name) Description"
+    "description": "12dPL function Get_project_setting_integer"
   },
   {
     "name": "Get_project_setting_text",
@@ -43608,7 +43832,7 @@
         "type": "Text"
       }
     ],
-    "description": "ID = 3549 Project Setting Page 915 12d Model Macro Manual Get_project_setting_colour(Text name) Name Integer Get_project_setting_colour(Text name) Description"
+    "description": "12dPL function Get_project_setting_text"
   },
   {
     "name": "Set_project_setting_integer",
@@ -43640,7 +43864,7 @@
         "type": "Real"
       }
     ],
-    "description": "ID = 3553 Set_project_setting_text(Text name,Text value) Name Integer Set_project_setting_text(Text name,Text value) Description"
+    "description": "12dPL function Set_project_setting_real"
   },
   {
     "name": "Set_project_setting_colour",
@@ -45015,7 +45239,19 @@
         "type": "Widget"
       }
     ],
-    "description": "When a Widget is created, it is given a unique identifying number (id) in the project. This function get the id of the Widget widget and returns id as the function return value. That is, the Integer function return value is the Widget id. D = 879 Set_focus(Widget widget) Name Integer Set_focus(Widget widget) Description Set the focus to the typed input area for an Input Widget widget, or on the button for a Button Widget widget. After this call all typed input will go to this widget. A function return value of zero indicates the focus was successfully set."
+    "description": "When a Widget is created, it is given a unique identifying number (id) in the project. This function get the id of the Widget widget and returns id as the function return value. That is, the Integer function return value is the Widget id."
+  },
+  {
+    "name": "Set_focus",
+    "id": 1097,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "widget",
+        "type": "Widget"
+      }
+    ],
+    "description": "Set the focus to the typed input area for an Input Widget widget, or on the button for a Button Widget widget. After this call all typed input will go to this widget. A function return value of zero indicates the focus was successfully set."
   },
   {
     "name": "Set_tooltip",
@@ -51854,7 +52090,39 @@
         "type": "Text"
       }
     ],
-    "description": "Panels and Widgets Page 1163 12d Model Macro Manual Set the snap mode mode and snap control control for the Select_Button select. When snap mode is: Name_Snap 6 Tin_Snap 7 Model_Snap 8 the snap_text must be string name; tin name, model name accordingly, otherwise, leave the snap_text blank “”. A function return value of zero indicates the type was successfully set. Get_select_coordinate(Select_Button select,Real &x,Real &y,Real &z,Real &ch,Real &ht) Name Integer Get_select_coordinate(Select_Button select,Real &x,Real &y,Real &z,Real &ch,Real &ht) Description Get the coordinate of the selected snap point. The return value of x, y, z, ch and ht must be type of Real. A function return value of zero indicates the coordinate was successfully returned."
+    "description": "Set the snap mode mode and snap control control for the Select_Button select. When snap mode is: Name_Snap 6 Tin_Snap 7 Model_Snap 8 the snap_text must be string name; tin name, model name accordingly, otherwise, leave the snap_text blank “”. A function return value of zero indicates the type was successfully set."
+  },
+  {
+    "name": "Get_select_coordinate",
+    "id": 1047,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "select",
+        "type": "Select_Button"
+      },
+      {
+        "name": "x",
+        "type": "Real"
+      },
+      {
+        "name": "y",
+        "type": "Real"
+      },
+      {
+        "name": "z",
+        "type": "Real"
+      },
+      {
+        "name": "ch",
+        "type": "Real"
+      },
+      {
+        "name": "ht",
+        "type": "Real"
+      }
+    ],
+    "description": "Get the coordinate of the selected snap point. The return value of x, y, z, ch and ht must be type of Real. A function return value of zero indicates the coordinate was successfully returned."
   },
   {
     "name": "Create_help_button",
@@ -52882,7 +53150,31 @@
         "type": "Dynamic_Element"
       }
     ],
-    "description": "Drape all the Elements in the Model model onto the Tin tin. The draped Elements are returned in the Dynamic_Element draped_elts. A function return value of zero indicates the drape was successful. Drape(Tin tin,Dynamic_Element de, Dynamic_Element &draped_elts) Name Integer Drape(Tin tin,Dynamic_Element de, Dynamic_Element &draped_elts) Description Drape all the Elements in the Dynamic_Element de onto the Tin tin. The draped Elements are returned in the Dynamic_Element draped_elts. A function return value of zero indicates the drape was successful. Drape(Tin tin,Dynamic_Element de, Dynamic_Element &draped_elts, Integer create_supers) Name Integer Drape(Tin tin,Dynamic_Element de, Dynamic_Element &draped_elts, Integer create_supers) Description Drape all the Elements in the Dynamic_Element de onto the Tin tin. The draped Elements are returned in the Dynamic_Element draped_elts. The resulting elements in draped_elts will be super string only if create_supers is non zero. A function return value of zero indicates the drape was successful."
+    "description": "Drape all the Elements in the Model model onto the Tin tin. The draped Elements are returned in the Dynamic_Element draped_elts. A function return value of zero indicates the drape was successful."
+  },
+  {
+    "name": "Drape",
+    "id": 3790,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "tin",
+        "type": "Tin"
+      },
+      {
+        "name": "model",
+        "type": "Dynamic_Element"
+      },
+      {
+        "name": "draped_strings",
+        "type": "Dynamic_Element"
+      },
+      {
+        "name": "create_supers",
+        "type": "Integer"
+      }
+    ],
+    "description": "Drape all the Elements in the Dynamic_Element de onto the Tin tin. The draped Elements are returned in the Dynamic_Element draped_elts. The resulting elements in draped_elts will be super string only if create_supers is non zero. A function return value of zero indicates the drape was successful."
   },
   {
     "name": "Face_drape",
@@ -53766,7 +54058,31 @@
         "type": "Real"
       }
     ],
-    "description": "ID = 1440 Split_string(Element string,Real chainage,Element &string1,Element &string2) Name Integer Split_string(Element string,Real chainage,Element &string1,Element &string2) Description Split a string about a chainage for ELement string This will result in 2 new strings being created. The part that exists before Real chainage is returned in Element string1. The part that exists after Real chainage is returned in Element string2. General Page 1213 12d Model Macro Manual A function return value of zero indicates the split was successful."
+    "description": "12dPL function Polygons_clip"
+  },
+  {
+    "name": "Split_string",
+    "id": 543,
+    "returnType": "Integer",
+    "parameters": [
+      {
+        "name": "string",
+        "type": "Element"
+      },
+      {
+        "name": "chainage",
+        "type": "Real"
+      },
+      {
+        "name": "string1",
+        "type": "Element"
+      },
+      {
+        "name": "string2",
+        "type": "Element"
+      }
+    ],
+    "description": "Split a string about a chainage for ELement string This will result in 2 new strings being created. The part that exists before Real chainage is returned in Element string1. The part that exists after Real chainage is returned in Element string2. A function return value of zero indicates the split was successful."
   },
   {
     "name": "Join_strings",

--- a/tests/enrichedFunctions.test.ts
+++ b/tests/enrichedFunctions.test.ts
@@ -271,6 +271,61 @@ describe("functions.enriched.json validation against functions.compiler.json", (
 		expect(duplicates).toEqual([]);
 	});
 
+	test("no enriched description embeds another function's manual entry (issue #125)", () => {
+		// The manual extraction used the "ID = <number>" footer as the function-entry
+		// boundary. When that footer is malformed (e.g. "D = 879") or missing, the next
+		// function's manual block is swallowed into the previous function's description,
+		// e.g. Set_focus ended up buried inside Get_id. Detect any such embedded entry by
+		// the manual heading structure, which restates the signature around
+		// Name/Description:   Fn(<params>) Name <ReturnType> Fn(<params>) Description
+		const compilerNameSet = new Set(compilerFunctions.map((f) => f.name));
+		const headingBlock =
+			/([A-Z][A-Za-z0-9_]*)\s*\(([^)]*)\)\s+Name\s+[A-Za-z_][A-Za-z0-9_]*\s+\1\s*\([^)]*\)\s+Description\b/g;
+
+		const typeSig = (params: FunctionParam[]): string =>
+			params.map((p) => normalizeType(p.type).toLowerCase()).join(",");
+
+		// Parameter types as written in a manual heading, e.g.
+		// "Element elt,Real x[],Integer &num_pts" -> "element,real,integer".
+		const headingTypeSig = (rawParams: string): string => {
+			const trimmed = rawParams.trim();
+			if (trimmed === "") return "";
+			return trimmed
+				.split(",")
+				.map((p) => p.trim().split(/\s+/)[0].replace(/[^A-Za-z0-9_].*$/, "").toLowerCase())
+				.filter((t) => t.length > 0)
+				.join(",");
+		};
+
+		const merged: string[] = [];
+		for (const fn of enrichedFunctions) {
+			// A heading for the entry's own overload is a harmless self-restatement;
+			// only a heading for a *different* function/overload signals a swallowed entry.
+			const hostKey = `${fn.name.toLowerCase()}|${typeSig(fn.parameters)}`;
+			headingBlock.lastIndex = 0;
+			let m: RegExpExecArray | null;
+			while ((m = headingBlock.exec(fn.description)) !== null) {
+				const embeddedName = m[1];
+				if (!compilerNameSet.has(embeddedName)) continue;
+				const embeddedKey = `${embeddedName.toLowerCase()}|${headingTypeSig(m[2])}`;
+				if (embeddedKey !== hostKey) {
+					merged.push(
+						`${fn.name}(${typeSig(fn.parameters)}) embeds ${embeddedName}(${headingTypeSig(m[2])})`
+					);
+				}
+			}
+		}
+
+		if (merged.length > 0) {
+			console.warn(
+				`\n⚠ ${merged.length} enriched entries embed another function's manual entry ` +
+					`(swallowed via a malformed/missing "ID = ..." footer):\n` +
+					merged.map((d) => `  - ${d}`).join("\n")
+			);
+		}
+		expect(merged).toEqual([]);
+	});
+
 	test("summary statistics", () => {
 		const matchResults = {
 			"name+params": 0,


### PR DESCRIPTION
Closes #125.

## Problem

The documentation enrichment used the manual's `ID = <number>` footer as the function-entry boundary. When that footer was malformed (e.g. `D = 879` instead of `ID = 879`) or missing entirely, the **next** function's manual block was swallowed into the previous function's description — so functions like `Set_focus` lost their standalone documentation and their text ended up buried inside `Get_id`.

A sweep of `functions.enriched.json` found **12** such cross-entry merges (broader than the two in the issue), including same-name overload merges:

| Host entry | Swallowed entry |
| --- | --- |
| `Get_id(Widget)` | `Set_focus` |
| `Get_name(Tin, Text)` | `Tin_models` |
| `Get_pipe_data` (#78/#79) | `Set_pipe_data` ×3 + `Get_pipe_data` overload |
| `Get_3d_data#78` | `Get_3d_data` overloads + `Set_3d_data` |
| `Set_3d_data#81` | `Set_3d_data#83` |
| `Get_project_setting_integer` / `_text`, `Set_project_setting_real` | next setting function |
| `Set_select_snap_mode` | `Get_select_coordinate` (#1047) |
| `Drape#144` | `Drape#3790` |
| `Polygons_clip` | `Split_string` |

## Fix

Re-split merged descriptions on the **manual heading structure** — `Fn(...) Name <ReturnType> Fn(...) Description` — which is a reliable boundary that does not depend on the `ID = ...` footer:

- recovered **12 swallowed standalone entries** (`Set_focus`, `Tin_models`, `Set_pipe_data` ×3, `Get_pipe_data`, `Get_3d_data` ×2, `Set_3d_data`, `Get_select_coordinate`, `Drape`, `Split_string`), each matched to its compiler overload by name + parameter signature;
- trimmed the swallowed text back out of the 12 host descriptions and stripped leaked page-header / `ID =` footer artefacts;
- replaced the `Set_3d_data` placeholder with its recovered description;
- where a host's own description was genuinely lost (only a stray footer remained), fell back to a neutral `12dPL function <name>` placeholder instead of keeping the wrong, swallowed text.

Same-overload self-restatements (a function's own heading repeated inside its own description) are intentionally left untouched — they are not cross-entry merges.

## What's in this PR

- **`scripts/split-merged-enriched.ts`** — a re-runnable repair (alongside the existing `fix-enriched.ts`); dry-run by default, `--write` to apply. It documents the splitting/matching logic so the data can be regenerated.
- **`server/src/resources/functions.enriched.json`** — the repaired data (12 host edits, 12 recovered entries, 1 placeholder replacement).
- **`tests/enrichedFunctions.test.ts`** — a regression test that fails if any enriched description embeds another function/overload's manual entry.
- **`client/testFixture/enriched_doc_split.4dm`** — a hover smoke-test fixture that calls every recovered function, annotated with the description hover should now show.

## Verification

- Post-repair scan: **0** cross-entry merges remain.
- Full test suite: **541/541 pass**, including the new regression test, and every enriched entry now matches its compiler entry by name + params.
- The hover path (`PrototypeService`, which prefers enriched descriptions over compiler ones) was confirmed to return the recovered text for all recovered functions, while `Get_id` / `Get_name` hover no longer leaks the swallowed text.
- The new `.4dm` fixture validates with **zero** language-server diagnostics (`bun run scripts/validate-fixtures.ts client/testFixture --filter enriched_doc_split`).
