### PR TITLE
Docs: add community contributors and document v1.5.7 / v1.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,6 +426,21 @@ Release of [v1.3.0] to the VS Code Marketplace.
 
 ---
 
+## [v1.5.7] - (29/05/2026)
+
+### Bug Fixes
+- **For-Loop Header Variable Re-declaration** (#158): Variables declared in a `for` loop header (e.g. `for(Integer i = 0; ...)`) were incorrectly reported as re-declarations. Loop-header declarations are now scoped the same way as ordinary block-scoped variables.
+- **Preprocessor Define Substitution** (#159): Follow-up fixes to the header `#define` collection and substitution pass introduced in v1.5.6, resolving remaining false positives from macro-defined values.
+
+---
+
+## [v1.5.8] - (02/06/2026)
+
+### Bug Fixes
+- **Macro Comment Stripping** (#161): Comments inside a `#define` macro body are now stripped before the macro is substituted, so inline or trailing comments in a definition no longer corrupt the substituted value.
+
+---
+
 # Template
 
 ## [vX.X.X] - (Date)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,8 @@ Maintainer: Ben Olsen (ben@nightworks.dev)
 
 Main Contributor: Kamal Jarada
 
+Community Contributors: [Phil Temple-Watts](https://github.com/PhilTemple-Watts), [Kleber](https://github.com/KleberNZ) — and everyone who has reported bugs and suggested features.
+
 ---
 
 Thanks for contributing — pull requests, issues and documentation improvements are welcome.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This repository’s documentation is split into the following Markdown files:
 
 ---
 
-### What's New in v1.5.6
+### What's New in v1.5.8
 
 **Pass-by-Reference Temporary Value Warnings** ✨
 - Passing a literal or temporary value to a `&` (pass-by-reference) parameter now produces a warning, since the callee cannot write back to a temporary
@@ -60,6 +60,9 @@ This repository’s documentation is split into the following Markdown files:
 - `#define` macros from included header files are now collected and substituted before validation, eliminating false positives from macro-defined values in headers
 
 **Bug Fixes**
+- Macro `#define` bodies now have comments stripped before substitution, so inline or trailing comments no longer corrupt the substituted value (v1.5.8)
+- `for` loop header variables (e.g. `for(Integer i = 0; ...)`) are no longer incorrectly flagged as re-declarations (v1.5.7)
+- Further fixes to preprocessor `#define` collection and substitution from headers (v1.5.7)
 - Switch statement formatting: cases with compound bodies are now indented correctly
 
 
@@ -168,4 +171,11 @@ Contributions welcome! Please submit pull requests or issues.
 
 **Ben Olsen**
 
-**Kamal Jarada** 
+**Kamal Jarada**
+
+### Community Contributors
+
+Thanks to everyone helping to improve the extension by reporting bugs and suggesting features:
+
+- [Phil Temple-Watts](https://github.com/PhilTemple-Watts)
+- [Kleber](https://github.com/KleberNZ)


### PR DESCRIPTION
## Summary

Adds the recent issue reporters as community contributors and brings the in-repo documentation up to the current `v1.5.8` (it was stale at `v1.5.6`).

## Community contributors

Recent issue reporters are acknowledged in a new **Community Contributors** section of the README and in `CONTRIBUTING.md`:

- [Phil Temple-Watts](https://github.com/PhilTemple-Watts) — reporter of #149–#151, #140, #134, #132, #104, #105, #98–#102 and more
- [Kleber](https://github.com/KleberNZ) — reporter of #125, #126, #127, #135, #146

`package.json`'s `contributors` field (npm code-author metadata) is intentionally left unchanged — these are community/issue contributors, acknowledged in the README/CONTRIBUTING instead.

## Documentation: v1.5.7 / v1.5.8

The `CHANGELOG.md` and the README "What's New" section stopped at `v1.5.6` while `package.json` is at `v1.5.8`. Following the repo's per-release doco convention, the missing versions are documented from their merged PRs (mapped via the package-bump commits):

- **v1.5.7** (29/05/2026): #158 — `for` loop header variable re-declaration fix; #159 — preprocessor `#define` substitution follow-up.
- **v1.5.8** (02/06/2026): #161 — strip comments from `#define` macro bodies before substitution.

The README "What's New" heading is retitled to `v1.5.8` with the new fixes listed.

## Notes

- Docs-only change; full test suite passes (540/540).
